### PR TITLE
Modify args encoding to support `null`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnolang/gno-js-client",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Gno JS / TS Client",
   "main": "./bin/index.js",
   "author": "Milos Zivkovic <milos.zivkovic@tendermint.com>",

--- a/proto/gno/vm.proto
+++ b/proto/gno/vm.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package gno.vm;
 
+import "google/protobuf/struct.proto";
+
 // MsgCall is the method invocation tx message,
 // denoted as "m_call"
 message MsgCall {
@@ -14,7 +16,7 @@ message MsgCall {
   // the function name being invoked
   string func = 4;
   // the function arguments
-  repeated string args = 5;
+  google.protobuf.Value args = 5; // null | string[]
 }
 
 // MsgAddPackage is the package deployment tx message,

--- a/src/proto/gno/bank.ts
+++ b/src/proto/gno/bank.ts
@@ -1,8 +1,8 @@
 /* eslint-disable */
-import Long from "long";
-import _m0 from "protobufjs/minimal";
+import Long from 'long';
+import _m0 from 'protobufjs/minimal';
 
-export const protobufPackage = "gno.bank";
+export const protobufPackage = 'gno.bank';
 
 /** MsgSend is the fund transfer tx message */
 export interface MsgSend {
@@ -15,25 +15,29 @@ export interface MsgSend {
 }
 
 function createBaseMsgSend(): MsgSend {
-  return { from_address: "", to_address: "", amount: "" };
+  return { from_address: '', to_address: '', amount: '' };
 }
 
 export const MsgSend = {
-  encode(message: MsgSend, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.from_address !== "") {
+  encode(
+    message: MsgSend,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.from_address !== '') {
       writer.uint32(10).string(message.from_address);
     }
-    if (message.to_address !== "") {
+    if (message.to_address !== '') {
       writer.uint32(18).string(message.to_address);
     }
-    if (message.amount !== "") {
+    if (message.amount !== '') {
       writer.uint32(26).string(message.amount);
     }
     return writer;
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): MsgSend {
-    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseMsgSend();
     while (reader.pos < end) {
@@ -71,21 +75,23 @@ export const MsgSend = {
 
   fromJSON(object: any): MsgSend {
     return {
-      from_address: isSet(object.from_address) ? String(object.from_address) : "",
-      to_address: isSet(object.to_address) ? String(object.to_address) : "",
-      amount: isSet(object.amount) ? String(object.amount) : "",
+      from_address: isSet(object.from_address)
+        ? String(object.from_address)
+        : '',
+      to_address: isSet(object.to_address) ? String(object.to_address) : '',
+      amount: isSet(object.amount) ? String(object.amount) : '',
     };
   },
 
   toJSON(message: MsgSend): unknown {
     const obj: any = {};
-    if (message.from_address !== "") {
+    if (message.from_address !== '') {
       obj.from_address = message.from_address;
     }
-    if (message.to_address !== "") {
+    if (message.to_address !== '') {
       obj.to_address = message.to_address;
     }
-    if (message.amount !== "") {
+    if (message.amount !== '') {
       obj.amount = message.amount;
     }
     return obj;
@@ -96,24 +102,40 @@ export const MsgSend = {
   },
   fromPartial<I extends Exact<DeepPartial<MsgSend>, I>>(object: I): MsgSend {
     const message = createBaseMsgSend();
-    message.from_address = object.from_address ?? "";
-    message.to_address = object.to_address ?? "";
-    message.amount = object.amount ?? "";
+    message.from_address = object.from_address ?? '';
+    message.to_address = object.to_address ?? '';
+    message.amount = object.amount ?? '';
     return message;
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
 
-export type DeepPartial<T> = T extends Builtin ? T
-  : T extends Long ? string | number | Long : T extends Array<infer U> ? Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
-  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+  ? string | number | Long
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & {
+      [K in Exclude<keyof I, KeysOfUnion<P>>]: never;
+    };
 
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;

--- a/src/proto/gno/bank.ts
+++ b/src/proto/gno/bank.ts
@@ -1,8 +1,8 @@
 /* eslint-disable */
-import Long from 'long';
-import _m0 from 'protobufjs/minimal';
+import Long from "long";
+import _m0 from "protobufjs/minimal";
 
-export const protobufPackage = 'gno.bank';
+export const protobufPackage = "gno.bank";
 
 /** MsgSend is the fund transfer tx message */
 export interface MsgSend {
@@ -15,29 +15,25 @@ export interface MsgSend {
 }
 
 function createBaseMsgSend(): MsgSend {
-  return { from_address: '', to_address: '', amount: '' };
+  return { from_address: "", to_address: "", amount: "" };
 }
 
 export const MsgSend = {
-  encode(
-    message: MsgSend,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.from_address !== '') {
+  encode(message: MsgSend, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.from_address !== "") {
       writer.uint32(10).string(message.from_address);
     }
-    if (message.to_address !== '') {
+    if (message.to_address !== "") {
       writer.uint32(18).string(message.to_address);
     }
-    if (message.amount !== '') {
+    if (message.amount !== "") {
       writer.uint32(26).string(message.amount);
     }
     return writer;
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): MsgSend {
-    const reader =
-      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseMsgSend();
     while (reader.pos < end) {
@@ -75,63 +71,49 @@ export const MsgSend = {
 
   fromJSON(object: any): MsgSend {
     return {
-      from_address: isSet(object.from_address)
-        ? String(object.from_address)
-        : '',
-      to_address: isSet(object.to_address) ? String(object.to_address) : '',
-      amount: isSet(object.amount) ? String(object.amount) : '',
+      from_address: isSet(object.from_address) ? String(object.from_address) : "",
+      to_address: isSet(object.to_address) ? String(object.to_address) : "",
+      amount: isSet(object.amount) ? String(object.amount) : "",
     };
   },
 
   toJSON(message: MsgSend): unknown {
     const obj: any = {};
-    message.from_address !== undefined &&
-      (obj.from_address = message.from_address);
-    message.to_address !== undefined && (obj.to_address = message.to_address);
-    message.amount !== undefined && (obj.amount = message.amount);
+    if (message.from_address !== "") {
+      obj.from_address = message.from_address;
+    }
+    if (message.to_address !== "") {
+      obj.to_address = message.to_address;
+    }
+    if (message.amount !== "") {
+      obj.amount = message.amount;
+    }
     return obj;
   },
 
   create<I extends Exact<DeepPartial<MsgSend>, I>>(base?: I): MsgSend {
-    return MsgSend.fromPartial(base ?? {});
+    return MsgSend.fromPartial(base ?? ({} as any));
   },
-
   fromPartial<I extends Exact<DeepPartial<MsgSend>, I>>(object: I): MsgSend {
     const message = createBaseMsgSend();
-    message.from_address = object.from_address ?? '';
-    message.to_address = object.to_address ?? '';
-    message.amount = object.amount ?? '';
+    message.from_address = object.from_address ?? "";
+    message.to_address = object.to_address ?? "";
+    message.amount = object.amount ?? "";
     return message;
   },
 };
 
-type Builtin =
-  | Date
-  | Function
-  | Uint8Array
-  | string
-  | number
-  | boolean
-  | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
-export type DeepPartial<T> = T extends Builtin
-  ? T
-  : T extends Long
-  ? string | number | Long
-  : T extends Array<infer U>
-  ? Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U>
-  ? ReadonlyArray<DeepPartial<U>>
-  : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+export type DeepPartial<T> = T extends Builtin ? T
+  : T extends Long ? string | number | Long : T extends Array<infer U> ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
+  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin
-  ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & {
-      [K in Exclude<keyof I, KeysOfUnion<P>>]: never;
-    };
+export type Exact<P, I extends P> = P extends Builtin ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;

--- a/src/proto/gno/vm.ts
+++ b/src/proto/gno/vm.ts
@@ -1,9 +1,9 @@
 /* eslint-disable */
-import Long from "long";
-import _m0 from "protobufjs/minimal";
-import { Value } from "../google/protobuf/struct";
+import Long from 'long';
+import _m0 from 'protobufjs/minimal';
+import { Value } from '../google/protobuf/struct';
 
-export const protobufPackage = "gno.vm";
+export const protobufPackage = 'gno.vm';
 
 /**
  * MsgCall is the method invocation tx message,
@@ -30,9 +30,7 @@ export interface MsgAddPackage {
   /** the package deployer */
   creator: string;
   /** the package being deployed */
-  package?:
-    | MemPackage
-    | undefined;
+  package?: MemPackage | undefined;
   /** the amount of funds to be deposited at deployment, if any ("<amount><denomination>") */
   deposit: string;
 }
@@ -62,21 +60,24 @@ export interface MemFile {
 }
 
 function createBaseMsgCall(): MsgCall {
-  return { caller: "", send: "", pkg_path: "", func: "", args: undefined };
+  return { caller: '', send: '', pkg_path: '', func: '', args: undefined };
 }
 
 export const MsgCall = {
-  encode(message: MsgCall, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.caller !== "") {
+  encode(
+    message: MsgCall,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.caller !== '') {
       writer.uint32(10).string(message.caller);
     }
-    if (message.send !== "") {
+    if (message.send !== '') {
       writer.uint32(18).string(message.send);
     }
-    if (message.pkg_path !== "") {
+    if (message.pkg_path !== '') {
       writer.uint32(26).string(message.pkg_path);
     }
-    if (message.func !== "") {
+    if (message.func !== '') {
       writer.uint32(34).string(message.func);
     }
     if (message.args !== undefined) {
@@ -86,7 +87,8 @@ export const MsgCall = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): MsgCall {
-    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseMsgCall();
     while (reader.pos < end) {
@@ -138,26 +140,26 @@ export const MsgCall = {
 
   fromJSON(object: any): MsgCall {
     return {
-      caller: isSet(object.caller) ? String(object.caller) : "",
-      send: isSet(object.send) ? String(object.send) : "",
-      pkg_path: isSet(object.pkg_path) ? String(object.pkg_path) : "",
-      func: isSet(object.func) ? String(object.func) : "",
+      caller: isSet(object.caller) ? String(object.caller) : '',
+      send: isSet(object.send) ? String(object.send) : '',
+      pkg_path: isSet(object.pkg_path) ? String(object.pkg_path) : '',
+      func: isSet(object.func) ? String(object.func) : '',
       args: isSet(object?.args) ? object.args : undefined,
     };
   },
 
   toJSON(message: MsgCall): unknown {
     const obj: any = {};
-    if (message.caller !== "") {
+    if (message.caller !== '') {
       obj.caller = message.caller;
     }
-    if (message.send !== "") {
+    if (message.send !== '') {
       obj.send = message.send;
     }
-    if (message.pkg_path !== "") {
+    if (message.pkg_path !== '') {
       obj.pkg_path = message.pkg_path;
     }
-    if (message.func !== "") {
+    if (message.func !== '') {
       obj.func = message.func;
     }
     if (message.args !== undefined) {
@@ -171,35 +173,39 @@ export const MsgCall = {
   },
   fromPartial<I extends Exact<DeepPartial<MsgCall>, I>>(object: I): MsgCall {
     const message = createBaseMsgCall();
-    message.caller = object.caller ?? "";
-    message.send = object.send ?? "";
-    message.pkg_path = object.pkg_path ?? "";
-    message.func = object.func ?? "";
+    message.caller = object.caller ?? '';
+    message.send = object.send ?? '';
+    message.pkg_path = object.pkg_path ?? '';
+    message.func = object.func ?? '';
     message.args = object.args ?? undefined;
     return message;
   },
 };
 
 function createBaseMsgAddPackage(): MsgAddPackage {
-  return { creator: "", package: undefined, deposit: "" };
+  return { creator: '', package: undefined, deposit: '' };
 }
 
 export const MsgAddPackage = {
-  encode(message: MsgAddPackage, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.creator !== "") {
+  encode(
+    message: MsgAddPackage,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.creator !== '') {
       writer.uint32(10).string(message.creator);
     }
     if (message.package !== undefined) {
       MemPackage.encode(message.package, writer.uint32(18).fork()).ldelim();
     }
-    if (message.deposit !== "") {
+    if (message.deposit !== '') {
       writer.uint32(26).string(message.deposit);
     }
     return writer;
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): MsgAddPackage {
-    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseMsgAddPackage();
     while (reader.pos < end) {
@@ -237,50 +243,60 @@ export const MsgAddPackage = {
 
   fromJSON(object: any): MsgAddPackage {
     return {
-      creator: isSet(object.creator) ? String(object.creator) : "",
-      package: isSet(object.package) ? MemPackage.fromJSON(object.package) : undefined,
-      deposit: isSet(object.deposit) ? String(object.deposit) : "",
+      creator: isSet(object.creator) ? String(object.creator) : '',
+      package: isSet(object.package)
+        ? MemPackage.fromJSON(object.package)
+        : undefined,
+      deposit: isSet(object.deposit) ? String(object.deposit) : '',
     };
   },
 
   toJSON(message: MsgAddPackage): unknown {
     const obj: any = {};
-    if (message.creator !== "") {
+    if (message.creator !== '') {
       obj.creator = message.creator;
     }
     if (message.package !== undefined) {
       obj.package = MemPackage.toJSON(message.package);
     }
-    if (message.deposit !== "") {
+    if (message.deposit !== '') {
       obj.deposit = message.deposit;
     }
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<MsgAddPackage>, I>>(base?: I): MsgAddPackage {
+  create<I extends Exact<DeepPartial<MsgAddPackage>, I>>(
+    base?: I
+  ): MsgAddPackage {
     return MsgAddPackage.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<MsgAddPackage>, I>>(object: I): MsgAddPackage {
+  fromPartial<I extends Exact<DeepPartial<MsgAddPackage>, I>>(
+    object: I
+  ): MsgAddPackage {
     const message = createBaseMsgAddPackage();
-    message.creator = object.creator ?? "";
-    message.package = (object.package !== undefined && object.package !== null)
-      ? MemPackage.fromPartial(object.package)
-      : undefined;
-    message.deposit = object.deposit ?? "";
+    message.creator = object.creator ?? '';
+    message.package =
+      object.package !== undefined && object.package !== null
+        ? MemPackage.fromPartial(object.package)
+        : undefined;
+    message.deposit = object.deposit ?? '';
     return message;
   },
 };
 
 function createBaseMemPackage(): MemPackage {
-  return { name: "", path: "", files: [] };
+  return { name: '', path: '', files: [] };
 }
 
 export const MemPackage = {
-  encode(message: MemPackage, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.name !== "") {
+  encode(
+    message: MemPackage,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.name !== '') {
       writer.uint32(10).string(message.name);
     }
-    if (message.path !== "") {
+    if (message.path !== '') {
       writer.uint32(18).string(message.path);
     }
     for (const v of message.files) {
@@ -290,7 +306,8 @@ export const MemPackage = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): MemPackage {
-    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseMemPackage();
     while (reader.pos < end) {
@@ -328,18 +345,20 @@ export const MemPackage = {
 
   fromJSON(object: any): MemPackage {
     return {
-      name: isSet(object.name) ? String(object.name) : "",
-      path: isSet(object.path) ? String(object.path) : "",
-      files: Array.isArray(object?.files) ? object.files.map((e: any) => MemFile.fromJSON(e)) : [],
+      name: isSet(object.name) ? String(object.name) : '',
+      path: isSet(object.path) ? String(object.path) : '',
+      files: Array.isArray(object?.files)
+        ? object.files.map((e: any) => MemFile.fromJSON(e))
+        : [],
     };
   },
 
   toJSON(message: MemPackage): unknown {
     const obj: any = {};
-    if (message.name !== "") {
+    if (message.name !== '') {
       obj.name = message.name;
     }
-    if (message.path !== "") {
+    if (message.path !== '') {
       obj.path = message.path;
     }
     if (message.files?.length) {
@@ -351,32 +370,38 @@ export const MemPackage = {
   create<I extends Exact<DeepPartial<MemPackage>, I>>(base?: I): MemPackage {
     return MemPackage.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<MemPackage>, I>>(object: I): MemPackage {
+  fromPartial<I extends Exact<DeepPartial<MemPackage>, I>>(
+    object: I
+  ): MemPackage {
     const message = createBaseMemPackage();
-    message.name = object.name ?? "";
-    message.path = object.path ?? "";
+    message.name = object.name ?? '';
+    message.path = object.path ?? '';
     message.files = object.files?.map((e) => MemFile.fromPartial(e)) || [];
     return message;
   },
 };
 
 function createBaseMemFile(): MemFile {
-  return { name: "", body: "" };
+  return { name: '', body: '' };
 }
 
 export const MemFile = {
-  encode(message: MemFile, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.name !== "") {
+  encode(
+    message: MemFile,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.name !== '') {
       writer.uint32(10).string(message.name);
     }
-    if (message.body !== "") {
+    if (message.body !== '') {
       writer.uint32(18).string(message.body);
     }
     return writer;
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): MemFile {
-    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseMemFile();
     while (reader.pos < end) {
@@ -406,15 +431,18 @@ export const MemFile = {
   },
 
   fromJSON(object: any): MemFile {
-    return { name: isSet(object.name) ? String(object.name) : "", body: isSet(object.body) ? String(object.body) : "" };
+    return {
+      name: isSet(object.name) ? String(object.name) : '',
+      body: isSet(object.body) ? String(object.body) : '',
+    };
   },
 
   toJSON(message: MemFile): unknown {
     const obj: any = {};
-    if (message.name !== "") {
+    if (message.name !== '') {
       obj.name = message.name;
     }
-    if (message.body !== "") {
+    if (message.body !== '') {
       obj.body = message.body;
     }
     return obj;
@@ -425,23 +453,39 @@ export const MemFile = {
   },
   fromPartial<I extends Exact<DeepPartial<MemFile>, I>>(object: I): MemFile {
     const message = createBaseMemFile();
-    message.name = object.name ?? "";
-    message.body = object.body ?? "";
+    message.name = object.name ?? '';
+    message.body = object.body ?? '';
     return message;
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
 
-export type DeepPartial<T> = T extends Builtin ? T
-  : T extends Long ? string | number | Long : T extends Array<infer U> ? Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
-  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+  ? string | number | Long
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & {
+      [K in Exclude<keyof I, KeysOfUnion<P>>]: never;
+    };
 
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;

--- a/src/proto/gno/vm.ts
+++ b/src/proto/gno/vm.ts
@@ -1,8 +1,9 @@
 /* eslint-disable */
-import Long from 'long';
-import _m0 from 'protobufjs/minimal';
+import Long from "long";
+import _m0 from "protobufjs/minimal";
+import { Value } from "../google/protobuf/struct";
 
-export const protobufPackage = 'gno.vm';
+export const protobufPackage = "gno.vm";
 
 /**
  * MsgCall is the method invocation tx message,
@@ -18,7 +19,7 @@ export interface MsgCall {
   /** the function name being invoked */
   func: string;
   /** the function arguments */
-  args: string[];
+  args?: any | undefined;
 }
 
 /**
@@ -29,7 +30,9 @@ export interface MsgAddPackage {
   /** the package deployer */
   creator: string;
   /** the package being deployed */
-  package?: MemPackage;
+  package?:
+    | MemPackage
+    | undefined;
   /** the amount of funds to be deposited at deployment, if any ("<amount><denomination>") */
   deposit: string;
 }
@@ -59,35 +62,31 @@ export interface MemFile {
 }
 
 function createBaseMsgCall(): MsgCall {
-  return { caller: '', send: '', pkg_path: '', func: '', args: [] };
+  return { caller: "", send: "", pkg_path: "", func: "", args: undefined };
 }
 
 export const MsgCall = {
-  encode(
-    message: MsgCall,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.caller !== '') {
+  encode(message: MsgCall, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.caller !== "") {
       writer.uint32(10).string(message.caller);
     }
-    if (message.send !== '') {
+    if (message.send !== "") {
       writer.uint32(18).string(message.send);
     }
-    if (message.pkg_path !== '') {
+    if (message.pkg_path !== "") {
       writer.uint32(26).string(message.pkg_path);
     }
-    if (message.func !== '') {
+    if (message.func !== "") {
       writer.uint32(34).string(message.func);
     }
-    for (const v of message.args) {
-      writer.uint32(42).string(v!);
+    if (message.args !== undefined) {
+      Value.encode(Value.wrap(message.args), writer.uint32(42).fork()).ldelim();
     }
     return writer;
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): MsgCall {
-    const reader =
-      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseMsgCall();
     while (reader.pos < end) {
@@ -126,7 +125,7 @@ export const MsgCall = {
             break;
           }
 
-          message.args.push(reader.string());
+          message.args = Value.unwrap(Value.decode(reader, reader.uint32()));
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -139,69 +138,68 @@ export const MsgCall = {
 
   fromJSON(object: any): MsgCall {
     return {
-      caller: isSet(object.caller) ? String(object.caller) : '',
-      send: isSet(object.send) ? String(object.send) : '',
-      pkg_path: isSet(object.pkg_path) ? String(object.pkg_path) : '',
-      func: isSet(object.func) ? String(object.func) : '',
-      args: Array.isArray(object?.args)
-        ? object.args.map((e: any) => String(e))
-        : [],
+      caller: isSet(object.caller) ? String(object.caller) : "",
+      send: isSet(object.send) ? String(object.send) : "",
+      pkg_path: isSet(object.pkg_path) ? String(object.pkg_path) : "",
+      func: isSet(object.func) ? String(object.func) : "",
+      args: isSet(object?.args) ? object.args : undefined,
     };
   },
 
   toJSON(message: MsgCall): unknown {
     const obj: any = {};
-    message.caller !== undefined && (obj.caller = message.caller);
-    message.send !== undefined && (obj.send = message.send);
-    message.pkg_path !== undefined && (obj.pkg_path = message.pkg_path);
-    message.func !== undefined && (obj.func = message.func);
-    if (message.args) {
-      obj.args = message.args.map((e) => e);
-    } else {
-      obj.args = [];
+    if (message.caller !== "") {
+      obj.caller = message.caller;
+    }
+    if (message.send !== "") {
+      obj.send = message.send;
+    }
+    if (message.pkg_path !== "") {
+      obj.pkg_path = message.pkg_path;
+    }
+    if (message.func !== "") {
+      obj.func = message.func;
+    }
+    if (message.args !== undefined) {
+      obj.args = message.args;
     }
     return obj;
   },
 
   create<I extends Exact<DeepPartial<MsgCall>, I>>(base?: I): MsgCall {
-    return MsgCall.fromPartial(base ?? {});
+    return MsgCall.fromPartial(base ?? ({} as any));
   },
-
   fromPartial<I extends Exact<DeepPartial<MsgCall>, I>>(object: I): MsgCall {
     const message = createBaseMsgCall();
-    message.caller = object.caller ?? '';
-    message.send = object.send ?? '';
-    message.pkg_path = object.pkg_path ?? '';
-    message.func = object.func ?? '';
-    message.args = object.args?.map((e) => e) || [];
+    message.caller = object.caller ?? "";
+    message.send = object.send ?? "";
+    message.pkg_path = object.pkg_path ?? "";
+    message.func = object.func ?? "";
+    message.args = object.args ?? undefined;
     return message;
   },
 };
 
 function createBaseMsgAddPackage(): MsgAddPackage {
-  return { creator: '', package: undefined, deposit: '' };
+  return { creator: "", package: undefined, deposit: "" };
 }
 
 export const MsgAddPackage = {
-  encode(
-    message: MsgAddPackage,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.creator !== '') {
+  encode(message: MsgAddPackage, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.creator !== "") {
       writer.uint32(10).string(message.creator);
     }
     if (message.package !== undefined) {
       MemPackage.encode(message.package, writer.uint32(18).fork()).ldelim();
     }
-    if (message.deposit !== '') {
+    if (message.deposit !== "") {
       writer.uint32(26).string(message.deposit);
     }
     return writer;
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): MsgAddPackage {
-    const reader =
-      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseMsgAddPackage();
     while (reader.pos < end) {
@@ -239,58 +237,50 @@ export const MsgAddPackage = {
 
   fromJSON(object: any): MsgAddPackage {
     return {
-      creator: isSet(object.creator) ? String(object.creator) : '',
-      package: isSet(object.package)
-        ? MemPackage.fromJSON(object.package)
-        : undefined,
-      deposit: isSet(object.deposit) ? String(object.deposit) : '',
+      creator: isSet(object.creator) ? String(object.creator) : "",
+      package: isSet(object.package) ? MemPackage.fromJSON(object.package) : undefined,
+      deposit: isSet(object.deposit) ? String(object.deposit) : "",
     };
   },
 
   toJSON(message: MsgAddPackage): unknown {
     const obj: any = {};
-    message.creator !== undefined && (obj.creator = message.creator);
-    message.package !== undefined &&
-      (obj.package = message.package
-        ? MemPackage.toJSON(message.package)
-        : undefined);
-    message.deposit !== undefined && (obj.deposit = message.deposit);
+    if (message.creator !== "") {
+      obj.creator = message.creator;
+    }
+    if (message.package !== undefined) {
+      obj.package = MemPackage.toJSON(message.package);
+    }
+    if (message.deposit !== "") {
+      obj.deposit = message.deposit;
+    }
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<MsgAddPackage>, I>>(
-    base?: I
-  ): MsgAddPackage {
-    return MsgAddPackage.fromPartial(base ?? {});
+  create<I extends Exact<DeepPartial<MsgAddPackage>, I>>(base?: I): MsgAddPackage {
+    return MsgAddPackage.fromPartial(base ?? ({} as any));
   },
-
-  fromPartial<I extends Exact<DeepPartial<MsgAddPackage>, I>>(
-    object: I
-  ): MsgAddPackage {
+  fromPartial<I extends Exact<DeepPartial<MsgAddPackage>, I>>(object: I): MsgAddPackage {
     const message = createBaseMsgAddPackage();
-    message.creator = object.creator ?? '';
-    message.package =
-      object.package !== undefined && object.package !== null
-        ? MemPackage.fromPartial(object.package)
-        : undefined;
-    message.deposit = object.deposit ?? '';
+    message.creator = object.creator ?? "";
+    message.package = (object.package !== undefined && object.package !== null)
+      ? MemPackage.fromPartial(object.package)
+      : undefined;
+    message.deposit = object.deposit ?? "";
     return message;
   },
 };
 
 function createBaseMemPackage(): MemPackage {
-  return { name: '', path: '', files: [] };
+  return { name: "", path: "", files: [] };
 }
 
 export const MemPackage = {
-  encode(
-    message: MemPackage,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.name !== '') {
+  encode(message: MemPackage, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.name !== "") {
       writer.uint32(10).string(message.name);
     }
-    if (message.path !== '') {
+    if (message.path !== "") {
       writer.uint32(18).string(message.path);
     }
     for (const v of message.files) {
@@ -300,8 +290,7 @@ export const MemPackage = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): MemPackage {
-    const reader =
-      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseMemPackage();
     while (reader.pos < end) {
@@ -339,62 +328,55 @@ export const MemPackage = {
 
   fromJSON(object: any): MemPackage {
     return {
-      name: isSet(object.name) ? String(object.name) : '',
-      path: isSet(object.path) ? String(object.path) : '',
-      files: Array.isArray(object?.files)
-        ? object.files.map((e: any) => MemFile.fromJSON(e))
-        : [],
+      name: isSet(object.name) ? String(object.name) : "",
+      path: isSet(object.path) ? String(object.path) : "",
+      files: Array.isArray(object?.files) ? object.files.map((e: any) => MemFile.fromJSON(e)) : [],
     };
   },
 
   toJSON(message: MemPackage): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.path !== undefined && (obj.path = message.path);
-    if (message.files) {
-      obj.files = message.files.map((e) => (e ? MemFile.toJSON(e) : undefined));
-    } else {
-      obj.files = [];
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.path !== "") {
+      obj.path = message.path;
+    }
+    if (message.files?.length) {
+      obj.files = message.files.map((e) => MemFile.toJSON(e));
     }
     return obj;
   },
 
   create<I extends Exact<DeepPartial<MemPackage>, I>>(base?: I): MemPackage {
-    return MemPackage.fromPartial(base ?? {});
+    return MemPackage.fromPartial(base ?? ({} as any));
   },
-
-  fromPartial<I extends Exact<DeepPartial<MemPackage>, I>>(
-    object: I
-  ): MemPackage {
+  fromPartial<I extends Exact<DeepPartial<MemPackage>, I>>(object: I): MemPackage {
     const message = createBaseMemPackage();
-    message.name = object.name ?? '';
-    message.path = object.path ?? '';
+    message.name = object.name ?? "";
+    message.path = object.path ?? "";
     message.files = object.files?.map((e) => MemFile.fromPartial(e)) || [];
     return message;
   },
 };
 
 function createBaseMemFile(): MemFile {
-  return { name: '', body: '' };
+  return { name: "", body: "" };
 }
 
 export const MemFile = {
-  encode(
-    message: MemFile,
-    writer: _m0.Writer = _m0.Writer.create()
-  ): _m0.Writer {
-    if (message.name !== '') {
+  encode(message: MemFile, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.name !== "") {
       writer.uint32(10).string(message.name);
     }
-    if (message.body !== '') {
+    if (message.body !== "") {
       writer.uint32(18).string(message.body);
     }
     return writer;
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): MemFile {
-    const reader =
-      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseMemFile();
     while (reader.pos < end) {
@@ -424,58 +406,42 @@ export const MemFile = {
   },
 
   fromJSON(object: any): MemFile {
-    return {
-      name: isSet(object.name) ? String(object.name) : '',
-      body: isSet(object.body) ? String(object.body) : '',
-    };
+    return { name: isSet(object.name) ? String(object.name) : "", body: isSet(object.body) ? String(object.body) : "" };
   },
 
   toJSON(message: MemFile): unknown {
     const obj: any = {};
-    message.name !== undefined && (obj.name = message.name);
-    message.body !== undefined && (obj.body = message.body);
+    if (message.name !== "") {
+      obj.name = message.name;
+    }
+    if (message.body !== "") {
+      obj.body = message.body;
+    }
     return obj;
   },
 
   create<I extends Exact<DeepPartial<MemFile>, I>>(base?: I): MemFile {
-    return MemFile.fromPartial(base ?? {});
+    return MemFile.fromPartial(base ?? ({} as any));
   },
-
   fromPartial<I extends Exact<DeepPartial<MemFile>, I>>(object: I): MemFile {
     const message = createBaseMemFile();
-    message.name = object.name ?? '';
-    message.body = object.body ?? '';
+    message.name = object.name ?? "";
+    message.body = object.body ?? "";
     return message;
   },
 };
 
-type Builtin =
-  | Date
-  | Function
-  | Uint8Array
-  | string
-  | number
-  | boolean
-  | undefined;
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
 
-export type DeepPartial<T> = T extends Builtin
-  ? T
-  : T extends Long
-  ? string | number | Long
-  : T extends Array<infer U>
-  ? Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U>
-  ? ReadonlyArray<DeepPartial<U>>
-  : T extends {}
-  ? { [K in keyof T]?: DeepPartial<T[K]> }
+export type DeepPartial<T> = T extends Builtin ? T
+  : T extends Long ? string | number | Long : T extends Array<infer U> ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
+  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin
-  ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & {
-      [K in Exclude<keyof I, KeysOfUnion<P>>]: never;
-    };
+export type Exact<P, I extends P> = P extends Builtin ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
 
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;

--- a/src/proto/google/protobuf/struct.ts
+++ b/src/proto/google/protobuf/struct.ts
@@ -1,0 +1,550 @@
+/* eslint-disable */
+import Long from "long";
+import _m0 from "protobufjs/minimal";
+
+export const protobufPackage = "google.protobuf";
+
+/**
+ * `NullValue` is a singleton enumeration to represent the null value for the
+ * `Value` type union.
+ *
+ * The JSON representation for `NullValue` is JSON `null`.
+ */
+export enum NullValue {
+  /** NULL_VALUE - Null value. */
+  NULL_VALUE = 0,
+  UNRECOGNIZED = -1,
+}
+
+export function nullValueFromJSON(object: any): NullValue {
+  switch (object) {
+    case 0:
+    case "NULL_VALUE":
+      return NullValue.NULL_VALUE;
+    case -1:
+    case "UNRECOGNIZED":
+    default:
+      return NullValue.UNRECOGNIZED;
+  }
+}
+
+export function nullValueToJSON(object: NullValue): string {
+  switch (object) {
+    case NullValue.NULL_VALUE:
+      return "NULL_VALUE";
+    case NullValue.UNRECOGNIZED:
+    default:
+      return "UNRECOGNIZED";
+  }
+}
+
+/**
+ * `Struct` represents a structured data value, consisting of fields
+ * which map to dynamically typed values. In some languages, `Struct`
+ * might be supported by a native representation. For example, in
+ * scripting languages like JS a struct is represented as an
+ * object. The details of that representation are described together
+ * with the proto support for the language.
+ *
+ * The JSON representation for `Struct` is JSON object.
+ */
+export interface Struct {
+  /** Unordered map of dynamically typed values. */
+  fields: { [key: string]: any | undefined };
+}
+
+export interface Struct_FieldsEntry {
+  key: string;
+  value?: any | undefined;
+}
+
+/**
+ * `Value` represents a dynamically typed value which can be either
+ * null, a number, a string, a boolean, a recursive struct value, or a
+ * list of values. A producer of value is expected to set one of these
+ * variants. Absence of any variant indicates an error.
+ *
+ * The JSON representation for `Value` is JSON value.
+ */
+export interface Value {
+  /** Represents a null value. */
+  null_value?:
+    | NullValue
+    | undefined;
+  /** Represents a double value. */
+  number_value?:
+    | number
+    | undefined;
+  /** Represents a string value. */
+  string_value?:
+    | string
+    | undefined;
+  /** Represents a boolean value. */
+  bool_value?:
+    | boolean
+    | undefined;
+  /** Represents a structured value. */
+  struct_value?:
+    | { [key: string]: any }
+    | undefined;
+  /** Represents a repeated `Value`. */
+  list_value?: Array<any> | undefined;
+}
+
+/**
+ * `ListValue` is a wrapper around a repeated field of values.
+ *
+ * The JSON representation for `ListValue` is JSON array.
+ */
+export interface ListValue {
+  /** Repeated field of dynamically typed values. */
+  values: any[];
+}
+
+function createBaseStruct(): Struct {
+  return { fields: {} };
+}
+
+export const Struct = {
+  encode(message: Struct, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    Object.entries(message.fields).forEach(([key, value]) => {
+      if (value !== undefined) {
+        Struct_FieldsEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).ldelim();
+      }
+    });
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Struct {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseStruct();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          const entry1 = Struct_FieldsEntry.decode(reader, reader.uint32());
+          if (entry1.value !== undefined) {
+            message.fields[entry1.key] = entry1.value;
+          }
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Struct {
+    return {
+      fields: isObject(object.fields)
+        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
+          acc[key] = value as any | undefined;
+          return acc;
+        }, {})
+        : {},
+    };
+  },
+
+  toJSON(message: Struct): unknown {
+    const obj: any = {};
+    if (message.fields) {
+      const entries = Object.entries(message.fields);
+      if (entries.length > 0) {
+        obj.fields = {};
+        entries.forEach(([k, v]) => {
+          obj.fields[k] = v;
+        });
+      }
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Struct>, I>>(base?: I): Struct {
+    return Struct.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
+    const message = createBaseStruct();
+    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
+      (acc, [key, value]) => {
+        if (value !== undefined) {
+          acc[key] = value;
+        }
+        return acc;
+      },
+      {},
+    );
+    return message;
+  },
+
+  wrap(object: { [key: string]: any } | undefined): Struct {
+    const struct = createBaseStruct();
+    if (object !== undefined) {
+      Object.keys(object).forEach((key) => {
+        struct.fields[key] = object[key];
+      });
+    }
+    return struct;
+  },
+
+  unwrap(message: Struct): { [key: string]: any } {
+    const object: { [key: string]: any } = {};
+    if (message.fields) {
+      Object.keys(message.fields).forEach((key) => {
+        object[key] = message.fields[key];
+      });
+    }
+    return object;
+  },
+};
+
+function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
+  return { key: "", value: undefined };
+}
+
+export const Struct_FieldsEntry = {
+  encode(message: Struct_FieldsEntry, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.key !== "") {
+      writer.uint32(10).string(message.key);
+    }
+    if (message.value !== undefined) {
+      Value.encode(Value.wrap(message.value), writer.uint32(18).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Struct_FieldsEntry {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseStruct_FieldsEntry();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          message.key = reader.string();
+          continue;
+        case 2:
+          if (tag !== 18) {
+            break;
+          }
+
+          message.value = Value.unwrap(Value.decode(reader, reader.uint32()));
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Struct_FieldsEntry {
+    return { key: isSet(object.key) ? String(object.key) : "", value: isSet(object?.value) ? object.value : undefined };
+  },
+
+  toJSON(message: Struct_FieldsEntry): unknown {
+    const obj: any = {};
+    if (message.key !== "") {
+      obj.key = message.key;
+    }
+    if (message.value !== undefined) {
+      obj.value = message.value;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(base?: I): Struct_FieldsEntry {
+    return Struct_FieldsEntry.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(object: I): Struct_FieldsEntry {
+    const message = createBaseStruct_FieldsEntry();
+    message.key = object.key ?? "";
+    message.value = object.value ?? undefined;
+    return message;
+  },
+};
+
+function createBaseValue(): Value {
+  return {
+    null_value: undefined,
+    number_value: undefined,
+    string_value: undefined,
+    bool_value: undefined,
+    struct_value: undefined,
+    list_value: undefined,
+  };
+}
+
+export const Value = {
+  encode(message: Value, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.null_value !== undefined) {
+      writer.uint32(8).int32(message.null_value);
+    }
+    if (message.number_value !== undefined) {
+      writer.uint32(17).double(message.number_value);
+    }
+    if (message.string_value !== undefined) {
+      writer.uint32(26).string(message.string_value);
+    }
+    if (message.bool_value !== undefined) {
+      writer.uint32(32).bool(message.bool_value);
+    }
+    if (message.struct_value !== undefined) {
+      Struct.encode(Struct.wrap(message.struct_value), writer.uint32(42).fork()).ldelim();
+    }
+    if (message.list_value !== undefined) {
+      ListValue.encode(ListValue.wrap(message.list_value), writer.uint32(50).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): Value {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseValue();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 8) {
+            break;
+          }
+
+          message.null_value = reader.int32() as any;
+          continue;
+        case 2:
+          if (tag !== 17) {
+            break;
+          }
+
+          message.number_value = reader.double();
+          continue;
+        case 3:
+          if (tag !== 26) {
+            break;
+          }
+
+          message.string_value = reader.string();
+          continue;
+        case 4:
+          if (tag !== 32) {
+            break;
+          }
+
+          message.bool_value = reader.bool();
+          continue;
+        case 5:
+          if (tag !== 42) {
+            break;
+          }
+
+          message.struct_value = Struct.unwrap(Struct.decode(reader, reader.uint32()));
+          continue;
+        case 6:
+          if (tag !== 50) {
+            break;
+          }
+
+          message.list_value = ListValue.unwrap(ListValue.decode(reader, reader.uint32()));
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): Value {
+    return {
+      null_value: isSet(object.null_value) ? nullValueFromJSON(object.null_value) : undefined,
+      number_value: isSet(object.number_value) ? Number(object.number_value) : undefined,
+      string_value: isSet(object.string_value) ? String(object.string_value) : undefined,
+      bool_value: isSet(object.bool_value) ? Boolean(object.bool_value) : undefined,
+      struct_value: isObject(object.struct_value) ? object.struct_value : undefined,
+      list_value: Array.isArray(object.list_value) ? [...object.list_value] : undefined,
+    };
+  },
+
+  toJSON(message: Value): unknown {
+    const obj: any = {};
+    if (message.null_value !== undefined) {
+      obj.null_value = nullValueToJSON(message.null_value);
+    }
+    if (message.number_value !== undefined) {
+      obj.number_value = message.number_value;
+    }
+    if (message.string_value !== undefined) {
+      obj.string_value = message.string_value;
+    }
+    if (message.bool_value !== undefined) {
+      obj.bool_value = message.bool_value;
+    }
+    if (message.struct_value !== undefined) {
+      obj.struct_value = message.struct_value;
+    }
+    if (message.list_value !== undefined) {
+      obj.list_value = message.list_value;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<Value>, I>>(base?: I): Value {
+    return Value.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<Value>, I>>(object: I): Value {
+    const message = createBaseValue();
+    message.null_value = object.null_value ?? undefined;
+    message.number_value = object.number_value ?? undefined;
+    message.string_value = object.string_value ?? undefined;
+    message.bool_value = object.bool_value ?? undefined;
+    message.struct_value = object.struct_value ?? undefined;
+    message.list_value = object.list_value ?? undefined;
+    return message;
+  },
+
+  wrap(value: any): Value {
+    const result = createBaseValue();
+    if (value === null) {
+      result.null_value = NullValue.NULL_VALUE;
+    } else if (typeof value === "boolean") {
+      result.bool_value = value;
+    } else if (typeof value === "number") {
+      result.number_value = value;
+    } else if (typeof value === "string") {
+      result.string_value = value;
+    } else if (Array.isArray(value)) {
+      result.list_value = value;
+    } else if (typeof value === "object") {
+      result.struct_value = value;
+    } else if (typeof value !== "undefined") {
+      throw new Error("Unsupported any value type: " + typeof value);
+    }
+    return result;
+  },
+
+  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined {
+    if (message.string_value !== undefined) {
+      return message.string_value;
+    } else if (message?.number_value !== undefined) {
+      return message.number_value;
+    } else if (message?.bool_value !== undefined) {
+      return message.bool_value;
+    } else if (message?.struct_value !== undefined) {
+      return message.struct_value as any;
+    } else if (message?.list_value !== undefined) {
+      return message.list_value;
+    } else if (message?.null_value !== undefined) {
+      return null;
+    }
+    return undefined;
+  },
+};
+
+function createBaseListValue(): ListValue {
+  return { values: [] };
+}
+
+export const ListValue = {
+  encode(message: ListValue, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    for (const v of message.values) {
+      Value.encode(Value.wrap(v!), writer.uint32(10).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): ListValue {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseListValue();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          message.values.push(Value.unwrap(Value.decode(reader, reader.uint32())));
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): ListValue {
+    return { values: Array.isArray(object?.values) ? [...object.values] : [] };
+  },
+
+  toJSON(message: ListValue): unknown {
+    const obj: any = {};
+    if (message.values?.length) {
+      obj.values = message.values;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<ListValue>, I>>(base?: I): ListValue {
+    return ListValue.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<ListValue>, I>>(object: I): ListValue {
+    const message = createBaseListValue();
+    message.values = object.values?.map((e) => e) || [];
+    return message;
+  },
+
+  wrap(array: Array<any> | undefined): ListValue {
+    const result = createBaseListValue();
+    result.values = array ?? [];
+    return result;
+  },
+
+  unwrap(message: ListValue): Array<any> {
+    if (message?.hasOwnProperty("values") && Array.isArray(message.values)) {
+      return message.values;
+    } else {
+      return message as any;
+    }
+  },
+};
+
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+
+export type DeepPartial<T> = T extends Builtin ? T
+  : T extends Long ? string | number | Long : T extends Array<infer U> ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
+  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+if (_m0.util.Long !== Long) {
+  _m0.util.Long = Long as any;
+  _m0.configure();
+}
+
+function isObject(value: any): boolean {
+  return typeof value === "object" && value !== null;
+}
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/src/proto/google/protobuf/struct.ts
+++ b/src/proto/google/protobuf/struct.ts
@@ -1,8 +1,8 @@
 /* eslint-disable */
-import Long from "long";
-import _m0 from "protobufjs/minimal";
+import Long from 'long';
+import _m0 from 'protobufjs/minimal';
 
-export const protobufPackage = "google.protobuf";
+export const protobufPackage = 'google.protobuf';
 
 /**
  * `NullValue` is a singleton enumeration to represent the null value for the
@@ -19,10 +19,10 @@ export enum NullValue {
 export function nullValueFromJSON(object: any): NullValue {
   switch (object) {
     case 0:
-    case "NULL_VALUE":
+    case 'NULL_VALUE':
       return NullValue.NULL_VALUE;
     case -1:
-    case "UNRECOGNIZED":
+    case 'UNRECOGNIZED':
     default:
       return NullValue.UNRECOGNIZED;
   }
@@ -31,10 +31,10 @@ export function nullValueFromJSON(object: any): NullValue {
 export function nullValueToJSON(object: NullValue): string {
   switch (object) {
     case NullValue.NULL_VALUE:
-      return "NULL_VALUE";
+      return 'NULL_VALUE';
     case NullValue.UNRECOGNIZED:
     default:
-      return "UNRECOGNIZED";
+      return 'UNRECOGNIZED';
   }
 }
 
@@ -68,25 +68,15 @@ export interface Struct_FieldsEntry {
  */
 export interface Value {
   /** Represents a null value. */
-  null_value?:
-    | NullValue
-    | undefined;
+  null_value?: NullValue | undefined;
   /** Represents a double value. */
-  number_value?:
-    | number
-    | undefined;
+  number_value?: number | undefined;
   /** Represents a string value. */
-  string_value?:
-    | string
-    | undefined;
+  string_value?: string | undefined;
   /** Represents a boolean value. */
-  bool_value?:
-    | boolean
-    | undefined;
+  bool_value?: boolean | undefined;
   /** Represents a structured value. */
-  struct_value?:
-    | { [key: string]: any }
-    | undefined;
+  struct_value?: { [key: string]: any } | undefined;
   /** Represents a repeated `Value`. */
   list_value?: Array<any> | undefined;
 }
@@ -106,17 +96,24 @@ function createBaseStruct(): Struct {
 }
 
 export const Struct = {
-  encode(message: Struct, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+  encode(
+    message: Struct,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
     Object.entries(message.fields).forEach(([key, value]) => {
       if (value !== undefined) {
-        Struct_FieldsEntry.encode({ key: key as any, value }, writer.uint32(10).fork()).ldelim();
+        Struct_FieldsEntry.encode(
+          { key: key as any, value },
+          writer.uint32(10).fork()
+        ).ldelim();
       }
     });
     return writer;
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): Struct {
-    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseStruct();
     while (reader.pos < end) {
@@ -144,10 +141,12 @@ export const Struct = {
   fromJSON(object: any): Struct {
     return {
       fields: isObject(object.fields)
-        ? Object.entries(object.fields).reduce<{ [key: string]: any | undefined }>((acc, [key, value]) => {
-          acc[key] = value as any | undefined;
-          return acc;
-        }, {})
+        ? Object.entries(object.fields).reduce<{
+            [key: string]: any | undefined;
+          }>((acc, [key, value]) => {
+            acc[key] = value as any | undefined;
+            return acc;
+          }, {})
         : {},
     };
   },
@@ -171,15 +170,14 @@ export const Struct = {
   },
   fromPartial<I extends Exact<DeepPartial<Struct>, I>>(object: I): Struct {
     const message = createBaseStruct();
-    message.fields = Object.entries(object.fields ?? {}).reduce<{ [key: string]: any | undefined }>(
-      (acc, [key, value]) => {
-        if (value !== undefined) {
-          acc[key] = value;
-        }
-        return acc;
-      },
-      {},
-    );
+    message.fields = Object.entries(object.fields ?? {}).reduce<{
+      [key: string]: any | undefined;
+    }>((acc, [key, value]) => {
+      if (value !== undefined) {
+        acc[key] = value;
+      }
+      return acc;
+    }, {});
     return message;
   },
 
@@ -205,22 +203,29 @@ export const Struct = {
 };
 
 function createBaseStruct_FieldsEntry(): Struct_FieldsEntry {
-  return { key: "", value: undefined };
+  return { key: '', value: undefined };
 }
 
 export const Struct_FieldsEntry = {
-  encode(message: Struct_FieldsEntry, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
-    if (message.key !== "") {
+  encode(
+    message: Struct_FieldsEntry,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.key !== '') {
       writer.uint32(10).string(message.key);
     }
     if (message.value !== undefined) {
-      Value.encode(Value.wrap(message.value), writer.uint32(18).fork()).ldelim();
+      Value.encode(
+        Value.wrap(message.value),
+        writer.uint32(18).fork()
+      ).ldelim();
     }
     return writer;
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): Struct_FieldsEntry {
-    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseStruct_FieldsEntry();
     while (reader.pos < end) {
@@ -250,12 +255,15 @@ export const Struct_FieldsEntry = {
   },
 
   fromJSON(object: any): Struct_FieldsEntry {
-    return { key: isSet(object.key) ? String(object.key) : "", value: isSet(object?.value) ? object.value : undefined };
+    return {
+      key: isSet(object.key) ? String(object.key) : '',
+      value: isSet(object?.value) ? object.value : undefined,
+    };
   },
 
   toJSON(message: Struct_FieldsEntry): unknown {
     const obj: any = {};
-    if (message.key !== "") {
+    if (message.key !== '') {
       obj.key = message.key;
     }
     if (message.value !== undefined) {
@@ -264,12 +272,16 @@ export const Struct_FieldsEntry = {
     return obj;
   },
 
-  create<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(base?: I): Struct_FieldsEntry {
+  create<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(
+    base?: I
+  ): Struct_FieldsEntry {
     return Struct_FieldsEntry.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(object: I): Struct_FieldsEntry {
+  fromPartial<I extends Exact<DeepPartial<Struct_FieldsEntry>, I>>(
+    object: I
+  ): Struct_FieldsEntry {
     const message = createBaseStruct_FieldsEntry();
-    message.key = object.key ?? "";
+    message.key = object.key ?? '';
     message.value = object.value ?? undefined;
     return message;
   },
@@ -301,16 +313,23 @@ export const Value = {
       writer.uint32(32).bool(message.bool_value);
     }
     if (message.struct_value !== undefined) {
-      Struct.encode(Struct.wrap(message.struct_value), writer.uint32(42).fork()).ldelim();
+      Struct.encode(
+        Struct.wrap(message.struct_value),
+        writer.uint32(42).fork()
+      ).ldelim();
     }
     if (message.list_value !== undefined) {
-      ListValue.encode(ListValue.wrap(message.list_value), writer.uint32(50).fork()).ldelim();
+      ListValue.encode(
+        ListValue.wrap(message.list_value),
+        writer.uint32(50).fork()
+      ).ldelim();
     }
     return writer;
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): Value {
-    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseValue();
     while (reader.pos < end) {
@@ -349,14 +368,18 @@ export const Value = {
             break;
           }
 
-          message.struct_value = Struct.unwrap(Struct.decode(reader, reader.uint32()));
+          message.struct_value = Struct.unwrap(
+            Struct.decode(reader, reader.uint32())
+          );
           continue;
         case 6:
           if (tag !== 50) {
             break;
           }
 
-          message.list_value = ListValue.unwrap(ListValue.decode(reader, reader.uint32()));
+          message.list_value = ListValue.unwrap(
+            ListValue.decode(reader, reader.uint32())
+          );
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -369,12 +392,24 @@ export const Value = {
 
   fromJSON(object: any): Value {
     return {
-      null_value: isSet(object.null_value) ? nullValueFromJSON(object.null_value) : undefined,
-      number_value: isSet(object.number_value) ? Number(object.number_value) : undefined,
-      string_value: isSet(object.string_value) ? String(object.string_value) : undefined,
-      bool_value: isSet(object.bool_value) ? Boolean(object.bool_value) : undefined,
-      struct_value: isObject(object.struct_value) ? object.struct_value : undefined,
-      list_value: Array.isArray(object.list_value) ? [...object.list_value] : undefined,
+      null_value: isSet(object.null_value)
+        ? nullValueFromJSON(object.null_value)
+        : undefined,
+      number_value: isSet(object.number_value)
+        ? Number(object.number_value)
+        : undefined,
+      string_value: isSet(object.string_value)
+        ? String(object.string_value)
+        : undefined,
+      bool_value: isSet(object.bool_value)
+        ? Boolean(object.bool_value)
+        : undefined,
+      struct_value: isObject(object.struct_value)
+        ? object.struct_value
+        : undefined,
+      list_value: Array.isArray(object.list_value)
+        ? [...object.list_value]
+        : undefined,
     };
   },
 
@@ -419,23 +454,25 @@ export const Value = {
     const result = createBaseValue();
     if (value === null) {
       result.null_value = NullValue.NULL_VALUE;
-    } else if (typeof value === "boolean") {
+    } else if (typeof value === 'boolean') {
       result.bool_value = value;
-    } else if (typeof value === "number") {
+    } else if (typeof value === 'number') {
       result.number_value = value;
-    } else if (typeof value === "string") {
+    } else if (typeof value === 'string') {
       result.string_value = value;
     } else if (Array.isArray(value)) {
       result.list_value = value;
-    } else if (typeof value === "object") {
+    } else if (typeof value === 'object') {
       result.struct_value = value;
-    } else if (typeof value !== "undefined") {
-      throw new Error("Unsupported any value type: " + typeof value);
+    } else if (typeof value !== 'undefined') {
+      throw new Error('Unsupported any value type: ' + typeof value);
     }
     return result;
   },
 
-  unwrap(message: any): string | number | boolean | Object | null | Array<any> | undefined {
+  unwrap(
+    message: any
+  ): string | number | boolean | Object | null | Array<any> | undefined {
     if (message.string_value !== undefined) {
       return message.string_value;
     } else if (message?.number_value !== undefined) {
@@ -458,7 +495,10 @@ function createBaseListValue(): ListValue {
 }
 
 export const ListValue = {
-  encode(message: ListValue, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+  encode(
+    message: ListValue,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
     for (const v of message.values) {
       Value.encode(Value.wrap(v!), writer.uint32(10).fork()).ldelim();
     }
@@ -466,7 +506,8 @@ export const ListValue = {
   },
 
   decode(input: _m0.Reader | Uint8Array, length?: number): ListValue {
-    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
     let end = length === undefined ? reader.len : reader.pos + length;
     const message = createBaseListValue();
     while (reader.pos < end) {
@@ -477,7 +518,9 @@ export const ListValue = {
             break;
           }
 
-          message.values.push(Value.unwrap(Value.decode(reader, reader.uint32())));
+          message.values.push(
+            Value.unwrap(Value.decode(reader, reader.uint32()))
+          );
           continue;
       }
       if ((tag & 7) === 4 || tag === 0) {
@@ -503,7 +546,9 @@ export const ListValue = {
   create<I extends Exact<DeepPartial<ListValue>, I>>(base?: I): ListValue {
     return ListValue.fromPartial(base ?? ({} as any));
   },
-  fromPartial<I extends Exact<DeepPartial<ListValue>, I>>(object: I): ListValue {
+  fromPartial<I extends Exact<DeepPartial<ListValue>, I>>(
+    object: I
+  ): ListValue {
     const message = createBaseListValue();
     message.values = object.values?.map((e) => e) || [];
     return message;
@@ -516,7 +561,7 @@ export const ListValue = {
   },
 
   unwrap(message: ListValue): Array<any> {
-    if (message?.hasOwnProperty("values") && Array.isArray(message.values)) {
+    if (message?.hasOwnProperty('values') && Array.isArray(message.values)) {
       return message.values;
     } else {
       return message as any;
@@ -524,17 +569,33 @@ export const ListValue = {
   },
 };
 
-type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+type Builtin =
+  | Date
+  | Function
+  | Uint8Array
+  | string
+  | number
+  | boolean
+  | undefined;
 
-export type DeepPartial<T> = T extends Builtin ? T
-  : T extends Long ? string | number | Long : T extends Array<infer U> ? Array<DeepPartial<U>>
-  : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
-  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
+export type DeepPartial<T> = T extends Builtin
+  ? T
+  : T extends Long
+  ? string | number | Long
+  : T extends Array<infer U>
+  ? Array<DeepPartial<U>>
+  : T extends ReadonlyArray<infer U>
+  ? ReadonlyArray<DeepPartial<U>>
+  : T extends {}
+  ? { [K in keyof T]?: DeepPartial<T[K]> }
   : Partial<T>;
 
 type KeysOfUnion<T> = T extends T ? keyof T : never;
-export type Exact<P, I extends P> = P extends Builtin ? P
-  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+export type Exact<P, I extends P> = P extends Builtin
+  ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & {
+      [K in Exclude<keyof I, KeysOfUnion<P>>]: never;
+    };
 
 if (_m0.util.Long !== Long) {
   _m0.util.Long = Long as any;
@@ -542,7 +603,7 @@ if (_m0.util.Long !== Long) {
 }
 
 function isObject(value: any): boolean {
-  return typeof value === "object" && value !== null;
+  return typeof value === 'object' && value !== null;
 }
 
 function isSet(value: any): boolean {

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -178,7 +178,7 @@ export class GnoWallet extends Wallet {
       send: amount,
       pkg_path: path,
       func: method,
-      args: args,
+      args: args.length === 0 ? null : args,
     };
 
     // Construct the transfer transaction


### PR DESCRIPTION
## Description

This PR modifies the proto definition for `MakeCall`, to allow for the `args` field to be marshalled as `null` if no arguments are specified.

Relevant TM2 amino encoding part that breaks this standard protobuf compatibility:
https://github.com/gnolang/gno/blob/master/tm2/pkg/amino/json_encode.go#L214-L219

Special thank you to @clockworkgr for figuring out this bug 🍻 