### PR TITLE
feat: Add basic realm module support to GnoWallet

### DIFF
--- a/src/wallet/helpers.ts
+++ b/src/wallet/helpers.ts
@@ -1,0 +1,23 @@
+import { GnoWallet } from "./wallet";
+
+export type Constructor<T> = new (...args: any[]) => T;
+
+export type AnyFunction = (...args: any) => any;
+
+export type UnionToIntersection<Union> =
+  (Union extends any
+    ? (argument: Union) => void
+    : never
+  ) extends (argument: infer Intersection) => void
+      ? Intersection
+  : never;
+
+export type Return<T> =
+  T extends AnyFunction
+  ? ReturnType<T>
+  : T extends AnyFunction[]
+  ? UnionToIntersection<ReturnType<T[number]>>
+      : never
+
+export type RealmInterface = { [key: string]: any }
+export type Realm = (instance: GnoWallet) => { realm: RealmInterface}

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -11,16 +11,33 @@ import Long from 'long';
 import { MemPackage, MsgAddPackage, MsgCall, MsgSend } from '../proto';
 import { MsgEndpoint } from './endpoints';
 import { LedgerConnector } from '@cosmjs/ledger-amino';
+import { Constructor, Realm, Return, UnionToIntersection } from './helpers';
 
 /**
  * GnoWallet is an extension of the TM2 wallet with
  * specific functionality for Gno chains
  */
 export class GnoWallet extends Wallet {
+
+	static realms: Realm[] = [];
   constructor() {
     super();
   }
+  static addRealm<T extends Realm | Realm[]>(realms: T) {
+    const currentRealms = this.realms;
 
+    class AugmentedWallet extends this {
+      static realms = currentRealms.concat(realms);
+    }
+
+    if (Array.isArray(realms)) {
+      type Extension = UnionToIntersection<Return<T>['realm']>
+      return AugmentedWallet as typeof GnoWallet & Constructor<Extension>;  
+    }
+
+    type Extension = Return<T>['realm']
+    return AugmentedWallet as typeof GnoWallet & Constructor<Extension>;
+  }
   /**
    * Generates a private key-based wallet, using a random seed
    * @param {AccountWalletOption} options the account options


### PR DESCRIPTION
Will provide this client and the GnoWallet class in particular to be extended with a type-safe API to specific contracts via realm-specific modules (ideally generated auto-magically)