### PR TITLE
Add support for `MsgRun` transaction execution

### DIFF
--- a/proto/gno/vm.proto
+++ b/proto/gno/vm.proto
@@ -37,7 +37,7 @@ message MsgRun {
   string caller = 1;
   // the amount of funds to be deposited to the package, if any ("<amount><denomination>")
   string send = 2;
-  // the package being execute
+  // the package being executed
   MemPackage package = 3;
 }
 

--- a/proto/gno/vm.proto
+++ b/proto/gno/vm.proto
@@ -45,18 +45,18 @@ message MsgRun {
 // package / realm deployment
 message MemPackage {
   // the name of the package
-  string name = 1;
+  string name = 1 [json_name = "Name"];
   // the gno path of the package
-  string path = 2;
+  string path = 2 [json_name = "Path"];
   // the associated package gno source
-  repeated MemFile files = 3;
+  repeated MemFile files = 3 [json_name = "Files"];
 }
 
 // MemFile is the metadata information tied to
 // a single gno package / realm file
 message MemFile {
   // the name of the source gno file
-  string name = 1;
+  string name = 1 [json_name = "Name"];
   // the content of the source gno file
-  string body = 2;
+  string body = 2 [json_name = "Body"];
 }

--- a/proto/gno/vm.proto
+++ b/proto/gno/vm.proto
@@ -30,6 +30,17 @@ message MsgAddPackage {
   string deposit = 3;
 }
 
+// MsgRun is the execute arbitrary Gno code tx message,
+// denoted as "m_run"
+message MsgRun {
+  // the bech32 address of the caller
+  string caller = 1;
+  // the amount of funds to be deposited to the package, if any ("<amount><denomination>")
+  string send = 2;
+  // the package being execute
+  MemPackage package = 3;
+}
+
 // MemPackage is the metadata information tied to
 // package / realm deployment
 message MemPackage {

--- a/src/proto/gno/vm.ts
+++ b/src/proto/gno/vm.ts
@@ -463,8 +463,8 @@ export const MemPackage = {
 
   fromJSON(object: any): MemPackage {
     return {
-      name: isSet(object.name) ? String(object.name) : '',
-      path: isSet(object.path) ? String(object.path) : '',
+      name: isSet(object.Name) ? String(object.Name) : '',
+      path: isSet(object.Path) ? String(object.Path) : '',
       files: Array.isArray(object?.files)
         ? object.files.map((e: any) => MemFile.fromJSON(e))
         : [],
@@ -474,13 +474,13 @@ export const MemPackage = {
   toJSON(message: MemPackage): unknown {
     const obj: any = {};
     if (message.name !== '') {
-      obj.name = message.name;
+      obj.Name = message.name;
     }
     if (message.path !== '') {
-      obj.path = message.path;
+      obj.Path = message.path;
     }
     if (message.files?.length) {
-      obj.files = message.files.map((e) => MemFile.toJSON(e));
+      obj.Files = message.files.map((e) => MemFile.toJSON(e));
     }
     return obj;
   },
@@ -550,18 +550,18 @@ export const MemFile = {
 
   fromJSON(object: any): MemFile {
     return {
-      name: isSet(object.name) ? String(object.name) : '',
-      body: isSet(object.body) ? String(object.body) : '',
+      name: isSet(object.Name) ? String(object.Name) : '',
+      body: isSet(object.Body) ? String(object.Body) : '',
     };
   },
 
   toJSON(message: MemFile): unknown {
     const obj: any = {};
     if (message.name !== '') {
-      obj.name = message.name;
+      obj.Name = message.name;
     }
     if (message.body !== '') {
-      obj.body = message.body;
+      obj.Body = message.body;
     }
     return obj;
   },

--- a/src/proto/gno/vm.ts
+++ b/src/proto/gno/vm.ts
@@ -35,6 +35,19 @@ export interface MsgAddPackage {
 }
 
 /**
+ * MsgRun is the execute arbitrary Gno code tx message,
+ * denoted as "m_run"
+ */
+export interface MsgRun {
+  /** the bech32 address of the caller */
+  caller: string;
+  /** the amount of funds to be deposited to the package, if any ("<amount><denomination>") */
+  send: string;
+  /** the package being execute */
+  package?: MemPackage | undefined;
+}
+
+/**
  * MemPackage is the metadata information tied to
  * package / realm deployment
  */
@@ -287,6 +300,104 @@ export const MsgAddPackage = {
         ? MemPackage.fromPartial(object.package)
         : undefined;
     message.deposit = object.deposit ?? '';
+    return message;
+  },
+};
+
+function createBaseMsgRun(): MsgRun {
+  return { caller: '', send: '', package: undefined };
+}
+
+export const MsgRun = {
+  encode(
+    message: MsgRun,
+    writer: _m0.Writer = _m0.Writer.create()
+  ): _m0.Writer {
+    if (message.caller !== '') {
+      writer.uint32(10).string(message.caller);
+    }
+    if (message.send !== '') {
+      writer.uint32(18).string(message.send);
+    }
+    if (message.package !== undefined) {
+      MemPackage.encode(message.package, writer.uint32(26).fork()).ldelim();
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgRun {
+    const reader =
+      input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgRun();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          message.caller = reader.string();
+          continue;
+        case 2:
+          if (tag !== 18) {
+            break;
+          }
+
+          message.send = reader.string();
+          continue;
+        case 3:
+          if (tag !== 26) {
+            break;
+          }
+
+          message.package = MemPackage.decode(reader, reader.uint32());
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgRun {
+    return {
+      caller: isSet(object.caller) ? String(object.caller) : '',
+      send: isSet(object.send) ? String(object.send) : '',
+      package: isSet(object.package)
+        ? MemPackage.fromJSON(object.package)
+        : undefined,
+    };
+  },
+
+  toJSON(message: MsgRun): unknown {
+    const obj: any = {};
+    if (message.caller !== '') {
+      obj.caller = message.caller;
+    }
+    if (message.send !== '') {
+      obj.send = message.send;
+    }
+    if (message.package !== undefined) {
+      obj.package = MemPackage.toJSON(message.package);
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<MsgRun>, I>>(base?: I): MsgRun {
+    return MsgRun.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<MsgRun>, I>>(object: I): MsgRun {
+    const message = createBaseMsgRun();
+    message.caller = object.caller ?? '';
+    message.send = object.send ?? '';
+    message.package =
+      object.package !== undefined && object.package !== null
+        ? MemPackage.fromPartial(object.package)
+        : undefined;
     return message;
   },
 };

--- a/src/wallet/endpoints.ts
+++ b/src/wallet/endpoints.ts
@@ -2,4 +2,5 @@ export enum MsgEndpoint {
   MSG_SEND = '/bank.MsgSend',
   MSG_ADD_PKG = '/vm.m_addpkg',
   MSG_CALL = '/vm.m_call',
+  MSG_RUN = '/vm.m_run',
 }

--- a/src/wallet/utility/utility.ts
+++ b/src/wallet/utility/utility.ts
@@ -1,4 +1,4 @@
-import { Any, MemPackage, MsgAddPackage, MsgCall, MsgSend } from '../../proto';
+import { Any, MsgAddPackage, MsgCall, MsgSend } from '../../proto';
 import { MsgRun } from '../../proto/gno/vm';
 import { MsgEndpoint } from '../endpoints';
 
@@ -39,57 +39,40 @@ export const defaultTxFee = '1000000ugnot'; // 1 GNOT
 export const decodeTxMessages = (messages: Any[]): any[] => {
   return messages.map((m: Any) => {
     switch (m.typeUrl) {
-      case MsgEndpoint.MSG_CALL:
+      case MsgEndpoint.MSG_CALL: {
+        const decodedMessage = MsgCall.decode(m.value);
+        const messageJson = MsgCall.toJSON(decodedMessage) as object;
         return {
           '@type': m.typeUrl,
-          ...MsgCall.decode(m.value),
+          ...messageJson,
         };
-      case MsgEndpoint.MSG_SEND:
+      }
+      case MsgEndpoint.MSG_SEND: {
+        const decodedMessage = MsgSend.decode(m.value);
+        const messageJson = MsgSend.toJSON(decodedMessage) as object;
         return {
           '@type': m.typeUrl,
-          ...MsgSend.decode(m.value),
+          ...messageJson,
         };
-      case MsgEndpoint.MSG_ADD_PKG:
-        const msgAddPkg = MsgAddPackage.decode(m.value);
+      }
+      case MsgEndpoint.MSG_ADD_PKG: {
+        const decodedMessage = MsgAddPackage.decode(m.value);
+        const messageJson = MsgAddPackage.toJSON(decodedMessage) as object;
         return {
           '@type': m.typeUrl,
-          ...msgAddPkg,
-          package: msgAddPkg.package
-            ? mapToStdMemPackage(msgAddPkg.package)
-            : undefined,
+          ...messageJson,
         };
-      case MsgEndpoint.MSG_RUN:
-        const msgRun = MsgRun.decode(m.value);
+      }
+      case MsgEndpoint.MSG_RUN: {
+        const decodedMessage = MsgRun.decode(m.value);
+        const messageJson = MsgRun.toJSON(decodedMessage) as object;
         return {
           '@type': m.typeUrl,
-          ...msgRun,
-          package: msgRun.package
-            ? mapToStdMemPackage(msgRun.package)
-            : undefined,
+          ...messageJson,
         };
+      }
       default:
         throw new Error(`unsupported message type ${m.typeUrl}`);
     }
   });
-};
-
-interface StdMemPackage {
-  Name: string;
-  Path: string;
-  Files: {
-    Name: string;
-    Body: string;
-  }[];
-}
-
-const mapToStdMemPackage = (memPackage: MemPackage): StdMemPackage => {
-  const { name, path, files } = memPackage;
-  return {
-    Name: name,
-    Path: path,
-    Files: files.map((file) => ({
-      Name: file.name,
-      Body: file.body,
-    })),
-  };
 };

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -258,7 +258,7 @@ export class GnoWallet extends Wallet {
 
   /**
    * Executes arbitrary Gno code
-   * @param {MemPackage} gnoPackage the package being execute
+   * @param {MemPackage} gnoPackage the gno package being executed
    * @param {TransactionEndpoint} endpoint the transaction broadcast type (sync / commit)
    * @param {Map<string, number>} [funds] the denomination -> value map for funds, if any
    * @param {TxFee} [fee] the custom transaction fee, if any

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -11,6 +11,7 @@ import Long from 'long';
 import { MemPackage, MsgAddPackage, MsgCall, MsgSend } from '../proto';
 import { MsgEndpoint } from './endpoints';
 import { LedgerConnector } from '@cosmjs/ledger-amino';
+import { MsgRun } from '../proto/gno/vm';
 
 /**
  * GnoWallet is an extension of the TM2 wallet with
@@ -241,6 +242,60 @@ export class GnoWallet extends Wallet {
         {
           typeUrl: MsgEndpoint.MSG_ADD_PKG,
           value: MsgAddPackage.encode(addPkgMsg).finish(),
+        },
+      ],
+      fee: txFee,
+      memo: '',
+      signatures: [], // No signature yet
+    };
+
+    // Sign the transaction
+    const signedTx: Tx = await this.signTransaction(tx, decodeTxMessages);
+
+    // Send the transaction
+    return this.sendTransaction(signedTx, endpoint);
+  };
+
+  /**
+   * Executes arbitrary Gno code
+   * @param {MemPackage} gnoPackage the package being execute
+   * @param {TransactionEndpoint} endpoint the transaction broadcast type (sync / commit)
+   * @param {Map<string, number>} [funds] the denomination -> value map for funds, if any
+   * @param {TxFee} [fee] the custom transaction fee, if any
+   */
+  executePackage = async <K extends keyof BroadcastTransactionMap>(
+    gnoPackage: MemPackage,
+    endpoint: K,
+    funds?: Map<string, number>,
+    fee?: TxFee
+  ): Promise<BroadcastTransactionMap[K]['result']> => {
+    // Convert the funds into the correct representation
+    const amount: string = fundsToCoins(funds);
+
+    // Fetch the wallet address
+    const caller: string = await this.getAddress();
+
+    // Construct the transaction fee
+    const txFee: TxFee = fee
+      ? fee
+      : {
+          gasWanted: new Long(60000),
+          gasFee: defaultTxFee,
+        };
+
+    // Prepare the Msg
+    const runMsg: MsgRun = {
+      caller,
+      send: amount,
+      package: gnoPackage,
+    };
+
+    // Construct the transfer transaction
+    const tx: Tx = {
+      messages: [
+        {
+          typeUrl: MsgEndpoint.MSG_RUN,
+          value: MsgRun.encode(runMsg).finish(),
         },
       ],
       fee: txFee,


### PR DESCRIPTION
## Description

This PR adds support for running transactions of type `vm.m_run`.  (https://github.com/gnolang/gno/pull/1001)

Additionally, since gno's `MemPackage` does not use json tags, 
I added a mapping to the decode function so that we can read data from gno.