### PR TITLE
fix: sign addpkg with empty deposit

### DIFF
--- a/src/proto/gno/vm.ts
+++ b/src/proto/gno/vm.ts
@@ -272,12 +272,12 @@ export const MsgAddPackage = {
   },
 
   toJSON(message: MsgAddPackage): unknown {
-    const obj: any = {};
+    const obj = createBaseMsgAddPackage();
     if (message.creator !== '') {
       obj.creator = message.creator;
     }
     if (message.package !== undefined) {
-      obj.package = MemPackage.toJSON(message.package);
+      obj.package = MemPackage.toJSON(message.package) as MemPackage;
     }
     if (message.deposit !== '') {
       obj.deposit = message.deposit;


### PR DESCRIPTION
Signing a transaction with a empty deposit field causes the following error:

```js
const msg = MsgAddPackage.create({
  deposit: "",
  package: MemPackage.create({
    name: "hello",
    path: "gno.land/r/demo/hello",
    files: [
		// ...
    ],
  }),
});
```

```
 log: '--= Error =--\n' +
'Data: std.UnauthorizedError{abciError:std.abciError{}}\n' +
'Msg Traces:\n' +
'    0  /opt/build/pkgs/std/errors.go:70 - signature verification failed; verify correct account sequence and chain-id\n' +
'Stack Trace:\n' +
'    0  /opt/build/pkgs/errors/errors.go:20\n' 
```

Kudos to the Onbloc team for quickly identifying the issue.