### PR TITLE
fix: resolve signature invalid error by including 'send' property in msgcall

### DIFF
--- a/src/wallet/utility/utility.ts
+++ b/src/wallet/utility/utility.ts
@@ -44,6 +44,7 @@ export const decodeTxMessages = (messages: Any[]): any[] => {
         const messageJson = MsgCall.toJSON(decodedMessage) as object;
         return {
           '@type': m.typeUrl,
+          send: '',
           ...messageJson,
         };
       }


### PR DESCRIPTION
Today, when using Gnowallet and attempting to execute [callMethod](https://github.com/gnolang/gno-js-client/blob/main/src/wallet/wallet.ts#L154) without funds in the parameters, we encounter a signature invalid error. This issue arises because during the signing process, we unintentionally omit the 'send' attribute, which is empty. However, on the backend, an empty string is utilized during marshaling https://github.com/gnolang/gno/blob/831bb6f92e1a2217242169dab1f4fd1f87e5eaa0/tm2/pkg/std/coin.go#L42-L61