### PR TITLE
Add `getBalance` Method to GnoLandClient Interface

### DIFF
--- a/packages/gno-type/README.md
+++ b/packages/gno-type/README.md
@@ -1,0 +1,7 @@
+# GNO Types
+
+TypeScript Interface for Gno.land
+
+## Functions
+
+- [getBalance](./actions/get-balance/get-balance.ts)

--- a/packages/gno-type/actions/get-balance/get-balance.test.ts
+++ b/packages/gno-type/actions/get-balance/get-balance.test.ts
@@ -1,0 +1,63 @@
+import {
+  getBalance,
+  GetBalanceParameters,
+  GetBalanceResponse,
+} from './get-balance';
+
+const mockGetBalance: getBalance = async (
+  param: GetBalanceParameters
+): Promise<GetBalanceResponse> => {
+  return {
+    address: param.address,
+    coins: [
+      {
+        symbol: 'ugnot',
+        amount: '9786000000',
+        decimals: 8,
+      },
+      {
+        symbol: 'myToken',
+        amount: '100',
+        decimals: 2,
+      },
+    ],
+  };
+};
+
+describe('getBalance', () => {
+  it('should return the correct balance', async () => {
+    const param: GetBalanceParameters = {
+      address: 'g1test',
+    };
+
+    const expectedResponse: GetBalanceResponse = {
+      address: 'g1test',
+      coins: [
+        {
+          symbol: 'ugnot',
+          amount: '9786000000',
+          decimals: 8,
+        },
+        {
+          symbol: 'myToken',
+          amount: '100',
+          decimals: 2,
+        },
+      ],
+    };
+
+    const response = await mockGetBalance(param);
+    expect(response).toEqual(expectedResponse);
+  });
+
+  it('sould accept an address with the correct format', async () => {
+    const param: GetBalanceParameters = {
+      address: 'g1test',
+    };
+
+    const response = await mockGetBalance(param);
+    expect(response.address).toEqual(param.address);
+  });
+
+  // TODO: Add more tests
+});

--- a/packages/gno-type/actions/get-balance/get-balance.ts
+++ b/packages/gno-type/actions/get-balance/get-balance.ts
@@ -1,0 +1,32 @@
+export type Address = `g1${string}`;
+
+export interface Coin {
+  symbol: string;
+  amount: string;
+  decimals: number;
+}
+
+export interface GetBalanceParameters {
+  address: Address;
+}
+
+export interface GetBalanceResponse {
+  address: Address;
+  coins: Coin[];
+}
+
+/**
+ * Get the balance of an address
+ *
+ * @param param.address - The address to get the balance of (must start with 'g1')
+ *
+ * @returns The balance of the address
+ *
+ * @throws Error if the address is not in the correct format
+ * @throws Error if the address does not exist
+ * @throws Error if the address has no balance
+ * @throws Error if the address has an invalid balance
+ * */
+export interface getBalance {
+  (param: GetBalanceParameters): Promise<GetBalanceResponse>;
+}


### PR DESCRIPTION
This PR adds the getBalance method to the GnoLandClient TypeScript interface. The getBalance method retrieves the balance of a specified account on the Gno.land blockchain.

The getBalance method is essential for querying the account balance, which is a fundamental feature for any dApp interacting with the Gno.land blockchain.