### PR TITLE
feat: add the changed syntax of the ABCI query

### DIFF
--- a/src/provider/jsonrpc/jsonrpc.ts
+++ b/src/provider/jsonrpc/jsonrpc.ts
@@ -8,7 +8,12 @@ import {
 } from '@gnolang/tm2-js-client';
 import { FunctionSignature } from '../types';
 import { VMEndpoint } from '../endpoints';
-import { extractStringFromResponse, prepareVMABCIQuery } from '../utility';
+import {
+  extractStringFromResponse,
+  prepareVMABCIEvaluateExpressionQuery,
+  prepareVMABCIQuery,
+  prepareVMABCIRenderQuery,
+} from '../utility';
 
 /**
  * Provider based on JSON-RPC HTTP requests
@@ -32,7 +37,7 @@ export class GnoJSONRPCProvider extends JSONRPCProvider implements GnoProvider {
       {
         request: newRequest(ABCIEndpoint.ABCI_QUERY, [
           `vm/${VMEndpoint.EVALUATE}`,
-          prepareVMABCIQuery([packagePath, expression]),
+          prepareVMABCIEvaluateExpressionQuery([packagePath, expression]),
           '0', // Height; not supported > 0 for now
           false,
         ]),
@@ -92,7 +97,7 @@ export class GnoJSONRPCProvider extends JSONRPCProvider implements GnoProvider {
       {
         request: newRequest(ABCIEndpoint.ABCI_QUERY, [
           `vm/${VMEndpoint.RENDER}`,
-          prepareVMABCIQuery([packagePath, path]),
+          prepareVMABCIRenderQuery([packagePath, path]),
           '0', // Height; not supported > 0 for now
           false,
         ]),

--- a/src/provider/utility/provider.utility.ts
+++ b/src/provider/utility/provider.utility.ts
@@ -2,21 +2,29 @@ import { stringToBase64 } from '@gnolang/tm2-js-client';
 
 /**
  * Prepares the VM ABCI query params by concatenating them
- * with new line or "." or ":" characters separation and encoding them to base64
+ * with characters separation and encoding them to base64
  * `evaluateExpression` uses the "." character to separate parameters.
  * `getRenderOutput` uses the ":" character to separate parameters.
  * @param {string[]} params the params for the ABCI call
- * @param {string} separator the separator for ABCI call parameters (default: "\n")
+ * @param {string} separator the separator for ABCI call parameters (default: "")
  */
-export const prepareVMABCIQuery = (
+export const prepareVMABCIQueryWithSeparator = (
   params: string[],
-  separator = '\n'
+  separator: string
 ): string => {
   if (params.length == 1) {
     return stringToBase64(params[0]);
   }
 
   return stringToBase64(params.join(separator));
+};
+
+/**
+ * Prepares the VM ABCI query parameters by concatenating characters and encoding them with base64.
+ * @param {string[]} params the params for the ABCI call
+ */
+export const prepareVMABCIQuery = (params: string[]): string => {
+  return prepareVMABCIQueryWithSeparator(params, '');
 };
 
 /**
@@ -27,7 +35,7 @@ export const prepareVMABCIQuery = (
 export const prepareVMABCIEvaluateExpressionQuery = (
   params: string[]
 ): string => {
-  return prepareVMABCIQuery(params, '.');
+  return prepareVMABCIQueryWithSeparator(params, '.');
 };
 
 /**
@@ -36,7 +44,7 @@ export const prepareVMABCIEvaluateExpressionQuery = (
  * @param {string[]} params the params for the ABCI call
  */
 export const prepareVMABCIRenderQuery = (params: string[]): string => {
-  return prepareVMABCIQuery(params, ':');
+  return prepareVMABCIQueryWithSeparator(params, ':');
 };
 
 export const extractStringFromResponse = (abciData: string | null): string => {

--- a/src/provider/utility/provider.utility.ts
+++ b/src/provider/utility/provider.utility.ts
@@ -2,15 +2,41 @@ import { stringToBase64 } from '@gnolang/tm2-js-client';
 
 /**
  * Prepares the VM ABCI query params by concatenating them
- * with a newline separation and encoding them to base64
+ * with new line or "." or ":" characters separation and encoding them to base64
+ * `evaluateExpression` uses the "." character to separate parameters.
+ * `getRenderOutput` uses the ":" character to separate parameters.
  * @param {string[]} params the params for the ABCI call
+ * @param {string} separator the separator for ABCI call parameters (default: "\n")
  */
-export const prepareVMABCIQuery = (params: string[]): string => {
+export const prepareVMABCIQuery = (
+  params: string[],
+  separator = '\n'
+): string => {
   if (params.length == 1) {
     return stringToBase64(params[0]);
   }
 
-  return stringToBase64(params.join('\n'));
+  return stringToBase64(params.join(separator));
+};
+
+/**
+ * Prepare the VM ABCI `evaluateExpression` query parameters by concatenating them
+ * with the "." character delimiter and encoding them with base64.
+ * @param {string[]} params the params for the ABCI call
+ */
+export const prepareVMABCIEvaluateExpressionQuery = (
+  params: string[]
+): string => {
+  return prepareVMABCIQuery(params, '.');
+};
+
+/**
+ * Prepare the VM ABCI `render` query parameters by concatenating them
+ * with the ":" character delimiter and encoding them with base64.
+ * @param {string[]} params the params for the ABCI call
+ */
+export const prepareVMABCIRenderQuery = (params: string[]): string => {
+  return prepareVMABCIQuery(params, ':');
 };
 
 export const extractStringFromResponse = (abciData: string | null): string => {

--- a/src/provider/websocket/ws.ts
+++ b/src/provider/websocket/ws.ts
@@ -7,7 +7,12 @@ import {
 } from '@gnolang/tm2-js-client';
 import { FunctionSignature } from '../types';
 import { VMEndpoint } from '../endpoints';
-import { extractStringFromResponse, prepareVMABCIQuery } from '../utility';
+import {
+  extractStringFromResponse,
+  prepareVMABCIEvaluateExpressionQuery,
+  prepareVMABCIQuery,
+  prepareVMABCIRenderQuery,
+} from '../utility';
 
 export class GnoWSProvider extends WSProvider implements GnoProvider {
   /**
@@ -27,7 +32,7 @@ export class GnoWSProvider extends WSProvider implements GnoProvider {
     const response = await this.sendRequest<ABCIResponse>(
       newRequest(ABCIEndpoint.ABCI_QUERY, [
         `vm/${VMEndpoint.EVALUATE}`,
-        prepareVMABCIQuery([packagePath, expression]),
+        prepareVMABCIEvaluateExpressionQuery([packagePath, expression]),
         '0', // Height; not supported > 0 for now
         false,
       ])
@@ -87,7 +92,7 @@ export class GnoWSProvider extends WSProvider implements GnoProvider {
     const response = await this.sendRequest<ABCIResponse>(
       newRequest(ABCIEndpoint.ABCI_QUERY, [
         `vm/${VMEndpoint.RENDER}`,
-        prepareVMABCIQuery([packagePath, path]),
+        prepareVMABCIRenderQuery([packagePath, path]),
         '0', // Height; not supported > 0 for now
         false,
       ])


### PR DESCRIPTION
# Descriptions

According to https://github.com/gnolang/gno/pull/2382,
change the request parameters of the ABCI query.

- Query for evaluation expression functions are encoded in `<pkgpath>.<expr>` format.
- Query for render functions are encoded in the `<pkgpath>:<path>` format.