### PR TITLE
feat: Define and add handler for `message noop`

### DIFF
--- a/proto/gno/vm.proto
+++ b/proto/gno/vm.proto
@@ -60,6 +60,7 @@ message MemFile {
 }
 
 // MsgNoop is the message for sponsor service
+// denoted as "m_noop"
 message MsgNoop {
   // the bech32 address of the caller
   string caller = 1;

--- a/proto/gno/vm.proto
+++ b/proto/gno/vm.proto
@@ -58,3 +58,9 @@ message MemFile {
   // the content of the source gno file
   string body = 2;
 }
+
+// MsgNoop is the message for sponsor service
+message MsgNoop {
+  // the bech32 address of the caller
+  string caller = 1;
+}

--- a/src/proto/gno/vm.ts
+++ b/src/proto/gno/vm.ts
@@ -71,6 +71,14 @@ export interface MemFile {
   body: string;
 }
 
+/**
+ * MsgNoop is the message for sponsor service
+ */
+export interface MsgNoop {
+  /** the bech32 address of the caller */
+  caller: string;
+}
+
 function createBaseMsgCall(): MsgCall {
   return { caller: '', send: '', pkg_path: '', func: '', args: null };
 }
@@ -575,6 +583,63 @@ export const MemFile = {
     const message = createBaseMemFile();
     message.name = object.name ?? '';
     message.body = object.body ?? '';
+    return message;
+  },
+};
+
+function createBaseMsgNoop(): MsgNoop {
+  return { caller: '' };
+}
+
+export const MsgNoop = {
+  encode(message: MsgNoop, writer: _m0.Writer = _m0.Writer.create()): _m0.Writer {
+    if (message.caller !== '') {
+      writer.uint32(10).string(message.caller);
+    }
+    return writer;
+  },
+
+  decode(input: _m0.Reader | Uint8Array, length?: number): MsgNoop {
+    const reader = input instanceof _m0.Reader ? input : _m0.Reader.create(input);
+    let end = length === undefined ? reader.len : reader.pos + length;
+    const message = createBaseMsgNoop();
+    while (reader.pos < end) {
+      const tag = reader.uint32();
+      switch (tag >>> 3) {
+        case 1:
+          if (tag !== 10) {
+            break;
+          }
+
+          message.caller = reader.string();
+          continue;
+      }
+      if ((tag & 7) === 4 || tag === 0) {
+        break;
+      }
+      reader.skipType(tag & 7);
+    }
+    return message;
+  },
+
+  fromJSON(object: any): MsgNoop {
+    return { caller: isSet(object.caller) ? globalThis.String(object.caller) : '' };
+  },
+
+  toJSON(message: MsgNoop): unknown {
+    const obj: any = {};
+    if (message.caller !== undefined) {
+      obj.caller = message.caller;
+    }
+    return obj;
+  },
+
+  create<I extends Exact<DeepPartial<MsgNoop>, I>>(base?: I): MsgNoop {
+    return MsgNoop.fromPartial(base ?? ({} as any));
+  },
+  fromPartial<I extends Exact<DeepPartial<MsgNoop>, I>>(object: I): MsgNoop {
+    const message = createBaseMsgNoop();
+    message.caller = object.caller ?? '';
     return message;
   },
 };

--- a/src/proto/gno/vm.ts
+++ b/src/proto/gno/vm.ts
@@ -73,6 +73,7 @@ export interface MemFile {
 
 /**
  * MsgNoop is the message for sponsor service
+ * denoted as "m_noop"
  */
 export interface MsgNoop {
   /** the bech32 address of the caller */

--- a/src/proto/index.ts
+++ b/src/proto/index.ts
@@ -1,3 +1,3 @@
 export { MsgSend } from './gno/bank';
-export { MsgAddPackage, MsgCall, MemFile, MemPackage } from './gno/vm';
+export { MsgAddPackage, MsgCall, MemFile, MemPackage, MsgNoop } from './gno/vm';
 export { Any } from './google/protobuf/any';

--- a/src/wallet/endpoints.ts
+++ b/src/wallet/endpoints.ts
@@ -3,4 +3,5 @@ export enum MsgEndpoint {
   MSG_ADD_PKG = '/vm.m_addpkg',
   MSG_CALL = '/vm.m_call',
   MSG_RUN = '/vm.m_run',
+  MSG_NOOP = '/vm.m_noop',
 }


### PR DESCRIPTION
Description:
This PR aims to support for sponsor service by defining, exporting proto of the `m_noop` - a type of message.

### Read more about sponsor-service at:
* Gno PRs: [#2630](https://github.com/gnolang/gno/pull/2630), [#2209](https://github.com/gnolang/gno/pull/2209)
* HackMD introduction [here](https://hackmd.io/@thinhnx/B1rtb2NtR)
* `updating...`