### PR TITLE
fix: fix a order of columns in proto

### DIFF
--- a/proto/gno/vm.proto
+++ b/proto/gno/vm.proto
@@ -11,14 +11,14 @@ message MsgCall {
   string caller = 1;
   // the amount of funds to be deposited to the package, if any ("<amount><denomination>")
   string send = 2;
-  // the gno package path
-  string pkg_path = 3;
-  // the function name being invoked
-  string func = 4;
-  // the function arguments
-  repeated string args = 5; // null | string[]
   // the amount of funds to lock for the storage, if any ("<amount><denomination>")
-  string max_deposit = 6;
+  string max_deposit = 3;
+  // the gno package path
+  string pkg_path = 4;
+  // the function name being invoked
+  string func = 5;
+  // the function arguments
+  repeated string args = 6; // null | string[]
 }
 
 // MsgAddPackage is the package deployment tx message,
@@ -41,10 +41,10 @@ message MsgRun {
   string caller = 1;
   // the amount of funds to be deposited to the package, if any ("<amount><denomination>")
   string send = 2;
-  // the package being executed
-  MemPackage package = 3;
   // the amount of funds to put down for the storage fee, if any ("<amount><denomination>")
-  string max_deposit = 4;
+  string max_deposit = 3;
+  // the package being executed
+  MemPackage package = 4;
 }
 
 // MemPackage is the metadata information tied to

--- a/src/proto/gno/vm.ts
+++ b/src/proto/gno/vm.ts
@@ -20,14 +20,14 @@ export interface MsgCall {
   caller: string;
   /** the amount of funds to be deposited to the package, if any ("<amount><denomination>") */
   send: string;
+  /** the amount of funds to lock for the storage, if any ("<amount><denomination>") */
+  max_deposit: string;
   /** the gno package path */
   pkg_path: string;
   /** the function name being invoked */
   func: string;
   /** the function arguments */
   args: string[] | null;
-  /** the amount of funds to lock for the storage, if any ("<amount><denomination>") */
-  max_deposit: string;
 }
 
 /**
@@ -54,10 +54,10 @@ export interface MsgRun {
   caller: string;
   /** the amount of funds to be deposited to the package, if any ("<amount><denomination>") */
   send: string;
-  /** the package being executed */
-  package?: MemPackage | undefined;
   /** the amount of funds to put down for the storage fee, if any ("<amount><denomination>") */
   max_deposit: string;
+  /** the package being executed */
+  package?: MemPackage | undefined;
 }
 
 /**
@@ -92,10 +92,10 @@ function createBaseMsgCall(): MsgCall {
   return {
     caller: '',
     send: '',
+    max_deposit: '',
     pkg_path: '',
     func: '',
     args: null,
-    max_deposit: '',
   };
 }
 
@@ -110,19 +110,17 @@ export const MsgCall: MessageFns<MsgCall> = {
     if (message.send !== '') {
       writer.uint32(18).string(message.send);
     }
+    if (message.max_deposit !== '') {
+      writer.uint32(26).string(message.max_deposit);
+    }
     if (message.pkg_path !== '') {
-      writer.uint32(26).string(message.pkg_path);
+      writer.uint32(34).string(message.pkg_path);
     }
     if (message.func !== '') {
-      writer.uint32(34).string(message.func);
+      writer.uint32(42).string(message.func);
     }
-    if (message.args) {
-      for (const v of message.args) {
-        writer.uint32(42).string(v!);
-      }
-    }
-    if (message.max_deposit !== '') {
-      writer.uint32(50).string(message.max_deposit);
+    for (const v of message.args) {
+      writer.uint32(50).string(v!);
     }
     return writer;
   },
@@ -156,7 +154,7 @@ export const MsgCall: MessageFns<MsgCall> = {
             break;
           }
 
-          message.pkg_path = reader.string();
+          message.max_deposit = reader.string();
           continue;
         }
         case 4: {
@@ -164,7 +162,7 @@ export const MsgCall: MessageFns<MsgCall> = {
             break;
           }
 
-          message.func = reader.string();
+          message.pkg_path = reader.string();
           continue;
         }
         case 5: {
@@ -172,11 +170,7 @@ export const MsgCall: MessageFns<MsgCall> = {
             break;
           }
 
-          if (!message.args) {
-            message.args = [];
-          }
-
-          message.args.push(reader.string());
+          message.func = reader.string();
           continue;
         }
         case 6: {
@@ -184,7 +178,7 @@ export const MsgCall: MessageFns<MsgCall> = {
             break;
           }
 
-          message.max_deposit = reader.string();
+          message.args.push(reader.string());
           continue;
         }
       }
@@ -200,16 +194,16 @@ export const MsgCall: MessageFns<MsgCall> = {
     return {
       caller: isSet(object.caller) ? globalThis.String(object.caller) : '',
       send: isSet(object.send) ? globalThis.String(object.send) : '',
+      max_deposit: isSet(object.max_deposit)
+        ? globalThis.String(object.max_deposit)
+        : '',
       pkg_path: isSet(object.pkg_path)
         ? globalThis.String(object.pkg_path)
         : '',
       func: isSet(object.func) ? globalThis.String(object.func) : '',
       args: globalThis.Array.isArray(object?.args)
         ? object.args.map((e: any) => globalThis.String(e))
-        : null,
-      max_deposit: isSet(object.max_deposit)
-        ? globalThis.String(object.max_deposit)
-        : '',
+        : [],
     };
   },
 
@@ -220,6 +214,9 @@ export const MsgCall: MessageFns<MsgCall> = {
     }
     if (message.send !== undefined) {
       obj.send = message.send;
+    }
+    if (message.max_deposit !== undefined) {
+      obj.max_deposit = message.max_deposit;
     }
     if (message.pkg_path !== undefined) {
       obj.pkg_path = message.pkg_path;
@@ -232,9 +229,6 @@ export const MsgCall: MessageFns<MsgCall> = {
     } else {
       obj.args = null;
     }
-    if (message.max_deposit !== undefined) {
-      obj.max_deposit = message.max_deposit;
-    }
     return obj;
   },
 
@@ -245,10 +239,10 @@ export const MsgCall: MessageFns<MsgCall> = {
     const message = createBaseMsgCall();
     message.caller = object.caller ?? '';
     message.send = object.send ?? '';
+    message.max_deposit = object.max_deposit ?? '';
     message.pkg_path = object.pkg_path ?? '';
     message.func = object.func ?? '';
     message.args = object.args?.map((e) => e) || [];
-    message.max_deposit = object.max_deposit ?? '';
     return message;
   },
 };
@@ -377,7 +371,7 @@ export const MsgAddPackage: MessageFns<MsgAddPackage> = {
 };
 
 function createBaseMsgRun(): MsgRun {
-  return { caller: '', send: '', package: undefined, max_deposit: '' };
+  return { caller: '', send: '', max_deposit: '', package: undefined };
 }
 
 export const MsgRun: MessageFns<MsgRun> = {
@@ -391,11 +385,11 @@ export const MsgRun: MessageFns<MsgRun> = {
     if (message.send !== '') {
       writer.uint32(18).string(message.send);
     }
-    if (message.package !== undefined) {
-      MemPackage.encode(message.package, writer.uint32(26).fork()).join();
-    }
     if (message.max_deposit !== '') {
-      writer.uint32(34).string(message.max_deposit);
+      writer.uint32(26).string(message.max_deposit);
+    }
+    if (message.package !== undefined) {
+      MemPackage.encode(message.package, writer.uint32(34).fork()).join();
     }
     return writer;
   },
@@ -429,7 +423,7 @@ export const MsgRun: MessageFns<MsgRun> = {
             break;
           }
 
-          message.package = MemPackage.decode(reader, reader.uint32());
+          message.max_deposit = reader.string();
           continue;
         }
         case 4: {
@@ -437,7 +431,7 @@ export const MsgRun: MessageFns<MsgRun> = {
             break;
           }
 
-          message.max_deposit = reader.string();
+          message.package = MemPackage.decode(reader, reader.uint32());
           continue;
         }
       }
@@ -453,12 +447,12 @@ export const MsgRun: MessageFns<MsgRun> = {
     return {
       caller: isSet(object.caller) ? globalThis.String(object.caller) : '',
       send: isSet(object.send) ? globalThis.String(object.send) : '',
-      package: isSet(object.package)
-        ? MemPackage.fromJSON(object.package)
-        : undefined,
       max_deposit: isSet(object.max_deposit)
         ? globalThis.String(object.max_deposit)
         : '',
+      package: isSet(object.package)
+        ? MemPackage.fromJSON(object.package)
+        : undefined,
     };
   },
 
@@ -470,11 +464,11 @@ export const MsgRun: MessageFns<MsgRun> = {
     if (message.send !== undefined) {
       obj.send = message.send;
     }
-    if (message.package !== undefined) {
-      obj.package = MemPackage.toJSON(message.package);
-    }
     if (message.max_deposit !== undefined) {
       obj.max_deposit = message.max_deposit;
+    }
+    if (message.package !== undefined) {
+      obj.package = MemPackage.toJSON(message.package);
     }
     return obj;
   },
@@ -486,11 +480,11 @@ export const MsgRun: MessageFns<MsgRun> = {
     const message = createBaseMsgRun();
     message.caller = object.caller ?? '';
     message.send = object.send ?? '';
+    message.max_deposit = object.max_deposit ?? '';
     message.package =
       object.package !== undefined && object.package !== null
         ? MemPackage.fromPartial(object.package)
         : undefined;
-    message.max_deposit = object.max_deposit ?? '';
     return message;
   },
 };

--- a/src/proto/gno/vm.ts
+++ b/src/proto/gno/vm.ts
@@ -119,8 +119,10 @@ export const MsgCall: MessageFns<MsgCall> = {
     if (message.func !== '') {
       writer.uint32(42).string(message.func);
     }
-    for (const v of message.args) {
-      writer.uint32(50).string(v!);
+    if (message.args) {
+      for (const v of message.args) {
+        writer.uint32(42).string(v!);
+      }
     }
     return writer;
   },
@@ -176,6 +178,10 @@ export const MsgCall: MessageFns<MsgCall> = {
         case 6: {
           if (tag !== 50) {
             break;
+          }
+
+          if (!message.args) {
+            message.args = [];
           }
 
           message.args.push(reader.string());


### PR DESCRIPTION
## Descriptions

This PR fixes the field ordering inconsistency in the Gno VM protobuf messages to ensure proper serialization/deserialization and maintain consistency across the codebase.

### Changes Made

#### Protocol Buffer Definitions (`proto/gno/vm.proto`)
- **MsgCall**: Moved `max_deposit` field from position 6 to position 3, reordering subsequent fields accordingly:
  - `max_deposit`: 6 → 3
  - `pkg_path`: 3 → 4  
  - `func`: 4 → 5
  - `args`: 5 → 6

- **MsgRun**: Moved `max_deposit` field from position 4 to position 3, and `package` from position 3 to position 4:
  - `max_deposit`: 4 → 3
  - `package`: 3 → 4

#### Generated TypeScript Code (`src/proto/gno/vm.ts`)
- Updated all corresponding TypeScript interfaces, encoding/decoding functions, and JSON serialization methods to match the new field ordering
- Fixed wire format encoding with correct field numbers
- Updated deserialization logic to handle the new field positions