### PR TITLE
feat: proto/amino compatibility hack

### DIFF
--- a/src/proto/gno/vm.ts
+++ b/src/proto/gno/vm.ts
@@ -496,7 +496,7 @@ export const MsgRun: MessageFns<MsgRun> = {
 };
 
 function createBaseMemPackage(): MemPackage {
-  return { name: '', path: '', files: [], type: undefined, info: undefined };
+  return { name: '', path: '', files: [], type: null, info: null };
 }
 
 export const MemPackage: MessageFns<MemPackage> = {
@@ -513,10 +513,10 @@ export const MemPackage: MessageFns<MemPackage> = {
     for (const v of message.files) {
       MemFile.encode(v!, writer.uint32(26).fork()).join();
     }
-    if (message.type !== undefined) {
+    if (message.type !== undefined && message.type !== null) {
       Any.encode(message.type, writer.uint32(34).fork()).join();
     }
-    if (message.info !== undefined) {
+    if (message.info !== undefined && message.info !== null) {
       Any.encode(message.info, writer.uint32(42).fork()).join();
     }
     return writer;
@@ -556,6 +556,7 @@ export const MemPackage: MessageFns<MemPackage> = {
         }
         case 4: {
           if (tag !== 34) {
+            message.type = null;
             break;
           }
 
@@ -564,6 +565,7 @@ export const MemPackage: MessageFns<MemPackage> = {
         }
         case 5: {
           if (tag !== 42) {
+            message.info = null;
             break;
           }
 
@@ -586,8 +588,8 @@ export const MemPackage: MessageFns<MemPackage> = {
       files: globalThis.Array.isArray(object?.files)
         ? object.files.map((e: any) => MemFile.fromJSON(e))
         : [],
-      type: isSet(object.type) ? Any.fromJSON(object.type) : undefined,
-      info: isSet(object.info) ? Any.fromJSON(object.info) : undefined,
+      type: isSet(object.type) ? Any.fromJSON(object.type) : null,
+      info: isSet(object.info) ? Any.fromJSON(object.info) : null,
     };
   },
 
@@ -602,11 +604,15 @@ export const MemPackage: MessageFns<MemPackage> = {
     if (message.files?.length) {
       obj.files = message.files.map((e) => MemFile.toJSON(e));
     }
-    if (message.type !== undefined) {
+    if (message.type !== undefined && message.type !== null) {
       obj.type = Any.toJSON(message.type);
+    }else{
+      obj.type = null;
     }
-    if (message.info !== undefined) {
+    if (message.info !== undefined && message.info !== null) {
       obj.info = Any.toJSON(message.info);
+    }else{
+      obj.info = null;
     }
     return obj;
   },
@@ -624,11 +630,11 @@ export const MemPackage: MessageFns<MemPackage> = {
     message.type =
       object.type !== undefined && object.type !== null
         ? Any.fromPartial(object.type)
-        : undefined;
+        : null;
     message.info =
       object.info !== undefined && object.info !== null
         ? Any.fromPartial(object.info)
-        : undefined;
+        : null;
     return message;
   },
 };

--- a/src/proto/gno/vm.ts
+++ b/src/proto/gno/vm.ts
@@ -42,7 +42,7 @@ export interface MsgAddPackage {
   /** the amount of funds to be deposited at deployment, if any ("<amount><denomination>") */
   send: string;
   /** the amount of funds to put down for the storage fee, if any ("<amount><denomination>") */
-  max_deposit: string;
+  max_deposit?: string;
 }
 
 /**
@@ -72,7 +72,7 @@ export interface MemPackage {
   /** the associated package gno source */
   files: MemFile[];
   /** the (user defined) package type */
-  type?: Any | null ;
+  type?: Any | null;
   /** the (user defined) extra information */
   info?: Any | null;
 }
@@ -221,7 +221,7 @@ export const MsgCall: MessageFns<MsgCall> = {
     if (message.send !== undefined) {
       obj.send = message.send;
     }
-    if (message.max_deposit !== undefined) {
+    if (message.max_deposit !== undefined && message.max_deposit !== "")  {
       obj.max_deposit = message.max_deposit;
     }
     if (message.pkg_path !== undefined) {
@@ -254,7 +254,7 @@ export const MsgCall: MessageFns<MsgCall> = {
 };
 
 function createBaseMsgAddPackage(): MsgAddPackage {
-  return { creator: '', package: undefined, send: '', max_deposit: '' };
+  return { creator: '', package: undefined, send: '', max_deposit: undefined };
 }
 
 export const MsgAddPackage: MessageFns<MsgAddPackage> = {
@@ -271,7 +271,7 @@ export const MsgAddPackage: MessageFns<MsgAddPackage> = {
     if (message.send !== '') {
       writer.uint32(26).string(message.send);
     }
-    if (message.max_deposit !== '') {
+    if (message.max_deposit !== '' && message.max_deposit !== undefined) {
       writer.uint32(34).string(message.max_deposit);
     }
     return writer;
@@ -313,8 +313,10 @@ export const MsgAddPackage: MessageFns<MsgAddPackage> = {
           if (tag !== 34) {
             break;
           }
-
-          message.max_deposit = reader.string();
+          const max_deposit = reader.string();
+          if (max_deposit!=='') {
+            message.max_deposit = max_deposit;
+          }
           continue;
         }
       }
@@ -335,7 +337,7 @@ export const MsgAddPackage: MessageFns<MsgAddPackage> = {
       send: isSet(object.send) ? globalThis.String(object.send) : '',
       max_deposit: isSet(object.max_deposit)
         ? globalThis.String(object.max_deposit)
-        : '',
+        : undefined,
     };
   },
 
@@ -371,7 +373,7 @@ export const MsgAddPackage: MessageFns<MsgAddPackage> = {
         ? MemPackage.fromPartial(object.package)
         : undefined;
     message.send = object.send ?? '';
-    message.max_deposit = object.max_deposit ?? '';
+    message.max_deposit = object.max_deposit ?? undefined;
     return message;
   },
 };
@@ -606,12 +608,12 @@ export const MemPackage: MessageFns<MemPackage> = {
     }
     if (message.type !== undefined && message.type !== null) {
       obj.type = Any.toJSON(message.type);
-    }else{
+    } else {
       obj.type = null;
     }
     if (message.info !== undefined && message.info !== null) {
       obj.info = Any.toJSON(message.info);
-    }else{
+    } else {
       obj.info = null;
     }
     return obj;

--- a/src/proto/gno/vm.ts
+++ b/src/proto/gno/vm.ts
@@ -72,9 +72,9 @@ export interface MemPackage {
   /** the associated package gno source */
   files: MemFile[];
   /** the (user defined) package type */
-  type?: Any | undefined;
+  type?: Any | null ;
   /** the (user defined) extra information */
-  info?: Any | undefined;
+  info?: Any | null;
 }
 
 /**


### PR DESCRIPTION
This is a very dirty manual intervention to the generated proto encoders/decoders to ensure MsgAddPackage decodes to the same JSON as Amino JSON in the core app so signatures can be verified.

Following on from https://github.com/gnolang/gno/issues/1166 in this scenario we have:

- Empty `max_deposit` is represented in JSON as `''` (empty string) in proto while omitted completely in Amino JSON
- Empty `google.protobuf.Any` fields are omitted in proto JSON while explicitly set to `null` in Amino JSON

This adjusts the behaviour of gno-js-client encoders/decoders to match Amino JSON.

However, adena includes a separate copy of this library instead of importing it (not sure why) so same changes need to be applied here: https://github.com/onbloc/adena-wallet/blob/main/packages/adena-module/src/libs/gno-js-client/proto/gno/vm.ts

Furthermore, Adena explicitly re-encodes and re-decodes the Tx messages (I'm guessing to ensure correctness and pretty Tx display) so the same adjustments must be performed here: https://github.com/onbloc/adena-wallet/blob/main/packages/adena-module/src/utils/messages.ts#L88-L148

In any case, proto/amino compatibility issues should be fixed in Amino's marshall to JSON methods rather than the client side so protobuf tooling can be used without issues