### PR TITLE
chore: export MsgRun from proto

### DIFF
--- a/src/proto/index.ts
+++ b/src/proto/index.ts
@@ -1,3 +1,3 @@
 export { MsgSend } from './gno/bank';
-export { MsgAddPackage, MsgCall, MemFile, MemPackage } from './gno/vm';
+export { MemFile, MemPackage, MsgAddPackage, MsgCall, MsgRun } from './gno/vm';
 export { Any } from './google/protobuf/any';


### PR DESCRIPTION
## Summary

This PR adds the missing `MsgRun` export to the proto index file and organizes all exports in alphabetical order for better maintainability.

## Changes

- Add `MsgRun` export to `src/proto/index.ts`