### PR TITLE
fix: correct MsgCall args field tag number in protobuf encoding

### DIFF
--- a/src/proto/gno/vm.ts
+++ b/src/proto/gno/vm.ts
@@ -121,7 +121,7 @@ export const MsgCall: MessageFns<MsgCall> = {
     }
     if (message.args) {
       for (const v of message.args) {
-        writer.uint32(42).string(v!);
+        writer.uint32(50).string(v!);
       }
     }
     return writer;


### PR DESCRIPTION
## Summary

This PR fixes an incorrect protobuf field tag number in the `MsgCall` message encoding. The `args` field was being encoded with tag number `42` instead of the correct tag number `50` that corresponds to field number `6` in the protobuf schema.

## Problem

The generated TypeScript code had an incorrect wire format tag number for the `MsgCall.args` field:
- **Incorrect**: `writer.uint32(42).string(v!)`
- **Correct**: `writer.uint32(50).string(v!)`

This mismatch between the protobuf schema definition and the generated encoding logic could cause:
- Serialization/deserialization errors
- Network protocol incompatibility 
- Transaction broadcast failures when using `MsgCall` with arguments

## Changes

- Updated `MsgCall.encode()` method to use correct tag number `50` for the `args` field
- This ensures proper serialization compatibility with the protobuf schema