### PR TITLE
ci: build gnodev from source to fix test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       # gnolang/gno has no v* release tags with prebuilt binaries, so the
       # installer's default download mode fails ("no v* release found").

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,9 +26,12 @@ jobs:
         with:
           go-version: '1.24'
 
-      # Install gnodev only when this PR will be merged: https://github.com/gnolang/gno/pull/4763
+      # gnolang/gno has no v* release tags with prebuilt binaries, so the
+      # installer's default download mode fails ("no v* release found").
       - name: Install gnodev
-        run: curl -sSL https://raw.githubusercontent.com/gnolang/gno/master/misc/install.sh | bash
+        run: |
+          curl -sSL https://raw.githubusercontent.com/gnolang/gno/master/misc/install.sh | bash -s -- --from-source
+          echo "$HOME/.gno/bin" >> "$GITHUB_PATH"
 
       - name: Tests
         run: pnpm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This file was reconstructed from git history and npm publish metadata to address
 [#241](https://github.com/gnolang/gno-js-client/issues/241). Going forward, please
 keep it up to date as part of the release process.
 
+## [Unreleased]
+
+- ci: build `gnodev` from source and bump Go to 1.25 to fix test workflow ([#248](https://github.com/gnolang/gno-js-client/pull/248))
+
 ## [2.0.2] - 2026-04-01
 
 Commit: [`0c078d6`](https://github.com/gnolang/gno-js-client/commit/0c078d69cad9f5851ac919d6140ff55a4cd3b1c5)


### PR DESCRIPTION
applied the changes for https://github.com/gnolang/gno/pull/5492